### PR TITLE
[TASK] Add rector to use enableFields from PageRepository directly

### DIFF
--- a/config/typo3-94.yaml
+++ b/config/typo3-94.yaml
@@ -1,2 +1,3 @@
 services:
   Ssch\TYPO3Rector\Core\Page\RefactorDeprecatedConcatenateMethodsPageRendererRector: ~
+  Ssch\TYPO3Rector\Frontend\ContentObject\CallEnableFieldsFromPageRepositoryRector: ~

--- a/src/Frontend/ContentObject/CallEnableFieldsFromPageRepositoryRector.php
+++ b/src/Frontend/ContentObject/CallEnableFieldsFromPageRepositoryRector.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Frontend\ContentObject;
+
+use PhpParser\BuilderHelpers;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\ConfiguredCodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+
+final class CallEnableFieldsFromPageRepositoryRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * Process Node of matched type.
+     *
+     * @param Node|MethodCall $node
+     *
+     * @return Node|null
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isObjectType($node, ContentObjectRenderer::class)) {
+            return null;
+        }
+
+        if (!$this->isName($node, 'enableFields')) {
+            return null;
+        }
+
+        $numberOfMethodArguments = count($node->args);
+        if ($numberOfMethodArguments > 1) {
+            $node->args[1] = new Node\Arg(BuilderHelpers::normalizeValue($this->isTrue($node->args[1]->value) ? true : -1));
+        }
+
+        $newNode = $this->createMethodCall($this->createStaticCall(
+            GeneralUtility::class,
+            'makeInstance',
+            [
+                $this->createClassConstant(PageRepository::class, 'class'),
+            ]
+        ), 'enableFields', $node->args);
+
+        return $newNode;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Turns method call names to new ones.', [
+            new ConfiguredCodeSample(
+                <<<'PHP'
+$contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+$contentObjectRenderer->enableFields('pages', false, []);
+$contentObjectRenderer->enableFields('pages', true);
+PHP
+                ,
+                <<<'PHP'
+$contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+GeneralUtility::makeInstance(PageRepository::class)->enableFields('pages', -1, []);
+GeneralUtility::makeInstance(PageRepository::class)->enableFields('pages', true);
+PHP
+            ),
+        ]);
+    }
+}

--- a/stubs/Frontend/ContentObject/ContentObjectRenderer.php
+++ b/stubs/Frontend/ContentObject/ContentObjectRenderer.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace TYPO3\CMS\Frontend\ContentObject;
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+
 final class ContentObjectRenderer
 {
     public function RECORDS(array $config): void
@@ -13,5 +16,10 @@ final class ContentObjectRenderer
 
     public function cObjGetSingle(string $string, array $config): void
     {
+    }
+
+    public function enableFields($table, $show_hidden = false, array $ignore_array = [])
+    {
+        return GeneralUtility::makeInstance(PageRepository::class)->enableFields($table, $show_hidden ? true : -1, $ignore_array);
     }
 }

--- a/stubs/Frontend/Page/PageRepository.php
+++ b/stubs/Frontend/Page/PageRepository.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\Frontend\Page;
+
+final class PageRepository
+{
+    public function enableFields($table, $show_hidden = -1, $ignore_array = [], $noVersionPreview = false): void
+    {
+    }
+}

--- a/tests/Frontend/Page/CallEnableFieldsFromPageRepositoryRectorTest.php
+++ b/tests/Frontend/Page/CallEnableFieldsFromPageRepositoryRectorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Frontend\Page;
+
+use Iterator;
+use Ssch\TYPO3Rector\Tests\AbstractRectorWithConfigTestCase;
+
+class CallEnableFieldsFromPageRepositoryRectorTest extends AbstractRectorWithConfigTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     *
+     * @param string $file
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/call_enable_fields_from_page_repository.php.inc'];
+    }
+}

--- a/tests/Frontend/Page/Fixture/call_enable_fields_from_page_repository.php.inc
+++ b/tests/Frontend/Page/Fixture/call_enable_fields_from_page_repository.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+final class ContentObjectRendererEnableFieldsMethodCall
+{
+    public function method(): void
+    {
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $enableFields1 = $contentObjectRenderer->enableFields('pages');
+        $enableFields2 = $contentObjectRenderer->enableFields('pages', true);
+        $enableFields3 = $contentObjectRenderer->enableFields('pages', false, []);
+    }
+}
+
+?>
+-----
+<?php
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+final class ContentObjectRendererEnableFieldsMethodCall
+{
+    public function method(): void
+    {
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $enableFields1 = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class)->enableFields('pages');
+        $enableFields2 = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class)->enableFields('pages', true);
+        $enableFields3 = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class)->enableFields('pages', -1, []);
+    }
+}
+
+?>


### PR DESCRIPTION
The public method \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer->enableFields() has been marked as deprecated
Use PageRepository->enableFields() directly

- Resolves: #1146