### PR TITLE
[TASK] Use UriBuilder instead of BackendUtility::getModuleUrl

### DIFF
--- a/config/typo3-93.php
+++ b/config/typo3-93.php
@@ -6,6 +6,7 @@ use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use function Rector\SymfonyPhpConfig\inline_value_objects;
 use Ssch\TYPO3Rector\Rector\Backend\Domain\Repository\Localization\RemoveColPosParameterRector;
+use Ssch\TYPO3Rector\Rector\Backend\Utility\BackendUtilityGetModuleUrlRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -25,4 +26,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 ),
             ]),
         ]]);
+
+    $services->set(BackendUtilityGetModuleUrlRector::class);
 };

--- a/src/Rector/Backend/Utility/BackendUtilityGetModuleUrlRector.php
+++ b/src/Rector/Backend/Utility/BackendUtilityGetModuleUrlRector.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector\Rector\Backend\Utility;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use Rector\Rector\AbstractRector;
-use Rector\RectorDefinition\CodeSample;
-use Rector\RectorDefinition\RectorDefinition;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -28,13 +29,17 @@ final class BackendUtilityGetModuleUrlRector extends AbstractRector
             return null;
         }
 
-        if (!$this->isName($node, 'getModuleUrl')) {
+        if (!$this->isName($node->name, 'getModuleUrl')) {
             return null;
         }
 
         /** @var Node\Arg[] $args */
         $args = $node->args;
         $firstArgument = array_shift($args);
+        if (null === $firstArgument) {
+            return null;
+        }
+
         $secondArgument = array_shift($args);
 
         return $this->createUriBuilderCall($firstArgument, $secondArgument);
@@ -70,7 +75,7 @@ PHP
         ]);
     }
 
-    private function createUriBuilderCall(Node\Arg $firstArgument, ?Node\Arg $secondArgument): MethodCall
+    private function createUriBuilderCall(Arg $firstArgument, ?Arg $secondArgument): MethodCall
     {
         $buildUriArguments = [$firstArgument->value];
         if (null !== $secondArgument) {
@@ -81,9 +86,7 @@ PHP
                     $this->createStaticCall(
                         GeneralUtility::class,
                         'makeInstance',
-                        [
-                            $this->createClassConstant(UriBuilder::class, 'class'),
-                        ]
+                        [$this->createClassConstantReference(UriBuilder::class)]
                     ), 'buildUriFromRoute', $buildUriArguments
                 );
     }

--- a/src/Rector/Backend/Utility/BackendUtilityGetModuleUrlRector.php
+++ b/src/Rector/Backend/Utility/BackendUtilityGetModuleUrlRector.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Rector\Backend\Utility;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @see https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.3/Deprecation-85113-LegacyBackendModuleRoutingMethods.html
+ */
+final class BackendUtilityGetModuleUrlRector extends AbstractRector
+{
+    /**
+     * @param StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isMethodStaticCallOrClassMethodObjectType($node, BackendUtility::class)) {
+            return null;
+        }
+
+        if (!$this->isName($node, 'getModuleUrl')) {
+            return null;
+        }
+
+        /** @var Node\Arg[] $args */
+        $args = $node->args;
+        $firstArgument = array_shift($args);
+        $secondArgument = array_shift($args);
+
+        return $this->createUriBuilderCall($firstArgument, $secondArgument);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Migrate the method BackendUtility::getModuleUrl() to use UriBuilder API', [
+            new CodeSample(
+                <<<'PHP'
+$moduleName = 'record_edit';
+$params = ['pid' => 2];
+$url = BackendUtility::getModuleUrl($moduleName, $params);
+PHP
+                ,
+                <<<'PHP'
+$moduleName = 'record_edit';
+$params = ['pid' => 2];
+$url = GeneralUtility::makeInstance(UriBuilder::class)->buildUriFromRoute($moduleName, $params);
+PHP
+            ),
+        ]);
+    }
+
+    private function createUriBuilderCall(Node\Arg $firstArgument, ?Node\Arg $secondArgument): MethodCall
+    {
+        $buildUriArguments = [$firstArgument->value];
+        if (null !== $secondArgument) {
+            $buildUriArguments[] = $secondArgument->value;
+        }
+
+        return $this->createMethodCall(
+                    $this->createStaticCall(
+                        GeneralUtility::class,
+                        'makeInstance',
+                        [
+                            $this->createClassConstant(UriBuilder::class, 'class'),
+                        ]
+                    ), 'buildUriFromRoute', $buildUriArguments
+                );
+    }
+}

--- a/src/Rector/Backend/Utility/BackendUtilityGetModuleUrlRector.php
+++ b/src/Rector/Backend/Utility/BackendUtilityGetModuleUrlRector.php
@@ -33,7 +33,7 @@ final class BackendUtilityGetModuleUrlRector extends AbstractRector
             return null;
         }
 
-        /** @var Node\Arg[] $args */
+        /** @var Arg[] $args */
         $args = $node->args;
         $firstArgument = array_shift($args);
         if (null === $firstArgument) {

--- a/stubs/Backend/Utility/BackendUtility.php
+++ b/stubs/Backend/Utility/BackendUtility.php
@@ -24,4 +24,9 @@ final class BackendUtility
     {
         return 'notice';
     }
+
+    public static function getModuleUrl($moduleName, $urlParameters = [])
+    {
+        return 'foo';
+    }
 }

--- a/tests/Rector/Backend/Utility/BackendUtilityGetModuleUrlRectorTest.php
+++ b/tests/Rector/Backend/Utility/BackendUtilityGetModuleUrlRectorTest.php
@@ -4,22 +4,23 @@ namespace Ssch\TYPO3Rector\Tests\Rector\Backend\Utility;
 
 use Iterator;
 use Ssch\TYPO3Rector\Tests\AbstractRectorWithConfigTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 class BackendUtilityGetModuleUrlRectorTest extends AbstractRectorWithConfigTestCase
 {
     /**
      * @dataProvider provideDataForTest()
      *
-     * @param string $file
+     * @param SmartFileInfo $file
      */
-    public function test(string $file): void
+    public function test(SmartFileInfo $file): void
     {
-        $this->doTestFile($file);
+        $this->doTestFileInfo($file);
     }
 
     public function provideDataForTest(): Iterator
     {
-        yield [__DIR__ . '/Fixture/backend_utility_get_module_url.php.inc'];
-        yield [__DIR__ . '/Fixture/backend_utility_get_module_url_no_second_param.php.inc'];
+        yield [new SmartFileInfo(__DIR__ . '/Fixture/backend_utility_get_module_url.php.inc')];
+        yield [new SmartFileInfo(__DIR__ . '/Fixture/backend_utility_get_module_url_no_second_param.php.inc')];
     }
 }

--- a/tests/Rector/Backend/Utility/BackendUtilityGetModuleUrlRectorTest.php
+++ b/tests/Rector/Backend/Utility/BackendUtilityGetModuleUrlRectorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\Backend\Utility;
+
+use Iterator;
+use Ssch\TYPO3Rector\Tests\AbstractRectorWithConfigTestCase;
+
+class BackendUtilityGetModuleUrlRectorTest extends AbstractRectorWithConfigTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     *
+     * @param string $file
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/backend_utility_get_module_url.php.inc'];
+        yield [__DIR__ . '/Fixture/backend_utility_get_module_url_no_second_param.php.inc'];
+    }
+}

--- a/tests/Rector/Backend/Utility/BackendUtilityGetModuleUrlRectorTest.php
+++ b/tests/Rector/Backend/Utility/BackendUtilityGetModuleUrlRectorTest.php
@@ -6,7 +6,7 @@ use Iterator;
 use Ssch\TYPO3Rector\Tests\AbstractRectorWithConfigTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-class BackendUtilityGetModuleUrlRectorTest extends AbstractRectorWithConfigTestCase
+final class BackendUtilityGetModuleUrlRectorTest extends AbstractRectorWithConfigTestCase
 {
     /**
      * @dataProvider provideDataForTest()

--- a/tests/Rector/Backend/Utility/Fixture/backend_utility_get_module_url.php.inc
+++ b/tests/Rector/Backend/Utility/Fixture/backend_utility_get_module_url.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+
+$moduleName = 'record_edit';
+$params = ['pid' => 2];
+$url = BackendUtility::getModuleUrl($moduleName, $params);
+
+?>
+-----
+<?php
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+
+$moduleName = 'record_edit';
+$params = ['pid' => 2];
+$url = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Routing\UriBuilder::class)->buildUriFromRoute($moduleName, $params);
+
+?>

--- a/tests/Rector/Backend/Utility/Fixture/backend_utility_get_module_url_no_second_param.php.inc
+++ b/tests/Rector/Backend/Utility/Fixture/backend_utility_get_module_url_no_second_param.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+
+$moduleName = 'record_edit';
+$url = BackendUtility::getModuleUrl($moduleName);
+
+?>
+-----
+<?php
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+
+$moduleName = 'record_edit';
+$url = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Routing\UriBuilder::class)->buildUriFromRoute($moduleName);
+
+?>


### PR DESCRIPTION
I'm not sure how to migrate the 'buildUriFromModule` deprecation properly.

Happy to get feedback, first real rector I wrote.