### PR TITLE
[TASK] Fix CascadeAnnotationRector for @cascade remove annotations

### DIFF
--- a/src/Rector/Annotation/CascadeAnnotationRector.php
+++ b/src/Rector/Annotation/CascadeAnnotationRector.php
@@ -6,6 +6,8 @@ namespace Ssch\TYPO3Rector\Rector\Annotation;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
@@ -23,7 +25,7 @@ final class CascadeAnnotationRector extends AbstractRector
     /**
      * @var string
      */
-    private $newAnnotation = 'TYPO3\CMS\Extbase\Annotation\ORM\Cascade';
+    private $newAnnotation = '@TYPO3\CMS\Extbase\Annotation\ORM\Cascade("remove")';
 
     public function getNodeTypes(): array
     {
@@ -39,7 +41,8 @@ final class CascadeAnnotationRector extends AbstractRector
             return null;
         }
 
-        $this->docBlockManipulator->replaceAnnotationInNode($node, $this->oldAnnotation, $this->newAnnotation);
+        $this->docBlockManipulator->removeTagFromNode($node, $this->oldAnnotation);
+        $this->docBlockManipulator->addTag($node, new PhpDocTagNode($this->newAnnotation, new GenericTagValueNode('')));
 
         return $node;
     }
@@ -62,7 +65,7 @@ CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
 /**
- * @TYPO3\CMS\Extbase\Annotation\ORM\Cascade
+ * @TYPO3\CMS\Extbase\Annotation\ORM\Cascade("remove")
  */
 private $someProperty;
 

--- a/tests/Rector/Annotation/AnnotationTest.php
+++ b/tests/Rector/Annotation/AnnotationTest.php
@@ -21,6 +21,7 @@ class AnnotationTest extends AbstractRectorWithConfigTestCase
     {
         yield [__DIR__ . '/Fixture/inject.php.inc'];
         yield [__DIR__ . '/Fixture/cascade.php.inc'];
+        yield [__DIR__ . '/Fixture/cascade_remove.php.inc'];
         yield [__DIR__ . '/Fixture/ignorevalidation.php.inc'];
         yield [__DIR__ . '/Fixture/lazy.php.inc'];
         yield [__DIR__ . '/Fixture/transient.php.inc'];

--- a/tests/Rector/Annotation/Fixture/cascade_remove.php.inc
+++ b/tests/Rector/Annotation/Fixture/cascade_remove.php.inc
@@ -2,10 +2,10 @@
 
 namespace Ssch\TYPO3Rector\Tests\Rector\Annotation\Fixture;
 
-final class SomeOtherClass
+final class SomeCascadeRemoveClass
 {
     /**
-     * @cascade
+     * @cascade remove
      */
     private $someProperty;
 }
@@ -16,7 +16,7 @@ final class SomeOtherClass
 
 namespace Ssch\TYPO3Rector\Tests\Rector\Annotation\Fixture;
 
-final class SomeOtherClass
+final class SomeCascadeRemoveClass
 {
     /**
      * @TYPO3\CMS\Extbase\Annotation\ORM\Cascade("remove")


### PR DESCRIPTION
Many projects use `@cascade remove` instead of `@cascade` alone.

This patch fixes rewriting these occurences of the annotation to the new namespaced versions.