### PR TITLE
fix autoloading issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,16 @@
     "autoload": {
         "psr-4": {
             "Ssch\\TYPO3Rector\\": "src"
-        }
+        },
+        "classmap": [
+            "classes"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
             "Ssch\\TYPO3Rector\\Tests\\": "tests"
         },
         "classmap": [
-            "classes",
             ".code"
         ]
     },


### PR DESCRIPTION
When using typo3-rector as composer package i'll get the following error since this commit
c89549be85d1e8ce21e253a7673c44dee09d06a7

`[ERROR] Class 'Symplify\PackageBuilder\Yaml\ParameterInImportResolver' not found`

I think the classmap should be defined in the "autoload" section instead of "autoload-dev".