### PR TITLE
[TASK] Apply renamed RenameMethodCallRector to config

### DIFF
--- a/config/typo3-80.yaml
+++ b/config/typo3-80.yaml
@@ -7,7 +7,7 @@ services:
     Ssch\TYPO3Rector\Rector\Frontend\ContentObject\RefactorRemovedMethodsFromContentObjectRendererRector: ~
     Ssch\TYPO3Rector\Rector\Extbase\RemovePropertyUserAuthenticationRector: ~
     Ssch\TYPO3Rector\Rector\Core\TimeTracker\TimeTrackerGlobalsToSingletonRector: ~
-    Rector\Renaming\Rector\MethodCall\RenameMethodCallRector:
+    Rector\Renaming\Rector\MethodCall\RenameMethodRector:
         $oldToNewMethodsByClass:
             TYPO3\CMS\Recordlist\RecordList:
                 printContent: mainAction

--- a/config/typo3-93.yaml
+++ b/config/typo3-93.yaml
@@ -3,7 +3,7 @@ imports:
 
 services:
     Ssch\TYPO3Rector\Rector\Backend\Domain\Repository\Localization\RemoveColPosParameterRector:
-    Rector\Renaming\Rector\MethodCall\RenameMethodCallRector:
+    Rector\Renaming\Rector\MethodCall\RenameMethodRector:
         $oldToNewMethodsByClass:
             TYPO3\CMS\Backend\Controller\Page\LocalizationController:
                 getUsedLanguagesInPageAndColumn: getUsedLanguagesInPage

--- a/config/typo3-95.yaml
+++ b/config/typo3-95.yaml
@@ -22,7 +22,7 @@ services:
     Ssch\TYPO3Rector\Rector\Core\Environment\ConstantToEnvironmentCallRector: ~
     Ssch\TYPO3Rector\Rector\Core\Package\UsePackageManagerActivePackagesRector: ~
     Ssch\TYPO3Rector\Rector\Core\Environment\RenameMethodCallToEnvironmentMethodCallRector: ~
-    Rector\Renaming\Rector\MethodCall\RenameMethodCallRector:
+    Rector\Renaming\Rector\MethodCall\RenameMethodRector:
         $oldToNewMethodsByClass:
             TYPO3\CMS\Core\Resource\ResourceStorage:
                 dumpFileContents: streamFile


### PR DESCRIPTION
As mentioned in the ChangeLog of the rector project
the rector RenameMethodCallRector has been renamed to
RenameMethodRector since version 0.7.49

See: https://github.com/rectorphp/rector/blob/0bef4d82622b3ebd2ad7fc474ef117a4a56d2487/CHANGELOG.md#v0749---2020-07-21