### PR TITLE
[TASK] Remove misleading .code folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,7 @@
 !/.php_cs.dist
 !/.travis.yml
 !.gitkeep
-!.code
-.code/*
-!.code/.gitkeep
+.code
 .class-alias-map-generator
 composer.lock
 # Other ignored paths and files.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
             "Ssch\\TYPO3Rector\\PHPStan\\": "utils/phpstan/src",
             "Ssch\\TYPO3Rector\\PHPStan\\Tests\\": "utils/phpstan/tests"
         },
-        "classmap": [".code"],
         "exclude-from-classmap": ["**.php.inc"]
     },
     "config": {


### PR DESCRIPTION
The .code folder is only for local testing purposes but confuses other contributors

Resolves: #1496