### PR TITLE
[TASK] Add @codeCoerageIgnore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 !/.gitignore
 !/.gitattributes
 !/.editorconfig
-!/.php_cs.dist
-!/.travis.yml
 !.gitkeep
 .code
 .class-alias-map-generator

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "analyze": "vendor/bin/phpstan analyse --memory-limit=-1 --ansi --error-format symplify",
         "test": "vendor/bin/phpunit",
         "docs": "vendor/bin/rector dump-rectors src/Rector > docs/AllRectorsOverview.md",
-        "rector": "vendor/bin/rector rectify --dry-run --ansi"
+        "rector": "vendor/bin/rector rectify --dry-run --ansi",
+        "fix-rector": "vendor/bin/rector rectify --ansi"
     },
     "scripts-descriptions": {
         "docs": "Regenerate descriptions of all Rectors to docs/AllRectorsOverview.md file"

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
 use Rector\Set\ValueObject\SetList;
+use Ssch\TYPO3Rector\Rector\Misc\AddCodeCoverageIgnoreToMethodRectorDefinitionRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -12,6 +13,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::SETS, [
         SetList::PRIVATIZATION, SetList::SOLID, SetList::DEAD_CODE, SetList::CODING_STYLE, SetList::CODE_QUALITY, ]
     );
+    $services = $containerConfigurator->services();
+
+    $services->set(AddCodeCoverageIgnoreToMethodRectorDefinitionRector::class);
 
     $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/tests']);
 };

--- a/src/Rector/Core/Database/DatabaseConnectionToDbalRector.php
+++ b/src/Rector/Core/Database/DatabaseConnectionToDbalRector.php
@@ -61,6 +61,9 @@ final class DatabaseConnectionToDbalRector extends AbstractRector
         return null;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition('Refactor legacy calls of DatabaseConnection to Dbal', [

--- a/src/Rector/Core/Html/RteHtmlParserRector.php
+++ b/src/Rector/Core/Html/RteHtmlParserRector.php
@@ -51,6 +51,9 @@ final class RteHtmlParserRector extends AbstractRector
         return null;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition(

--- a/src/Rector/Core/Resource/SubstituteResourceFactoryRector.php
+++ b/src/Rector/Core/Resource/SubstituteResourceFactoryRector.php
@@ -40,6 +40,9 @@ final class SubstituteResourceFactoryRector extends AbstractRector
         ]);
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition(

--- a/src/Rector/Core/Resource/UseMetaDataAspectRector.php
+++ b/src/Rector/Core/Resource/UseMetaDataAspectRector.php
@@ -40,6 +40,9 @@ final class UseMetaDataAspectRector extends AbstractRector
         return $this->createMethodCall($this->createMethodCall($node->var, 'getMetaData'), 'get');
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition('Use $fileObject->getMetaData()->get() instead of $fileObject->_getMetaData()', [

--- a/src/Rector/Core/Utility/RefactorIdnaEncodeMethodToNativeFunctionRector.php
+++ b/src/Rector/Core/Utility/RefactorIdnaEncodeMethodToNativeFunctionRector.php
@@ -59,6 +59,9 @@ final class RefactorIdnaEncodeMethodToNativeFunctionRector extends AbstractRecto
         return $this->refactorToEmailConcatWithNativeFunction($firstArgumentValue);
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition('Use native function idn_to_ascii instead of GeneralUtility::idnaEncode', [

--- a/src/Rector/Extbase/InjectEnvironmentServiceIfNeededInResponseRector.php
+++ b/src/Rector/Extbase/InjectEnvironmentServiceIfNeededInResponseRector.php
@@ -69,6 +69,9 @@ final class InjectEnvironmentServiceIfNeededInResponseRector extends AbstractRec
         return $node;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition(

--- a/src/Rector/Frontend/Page/RemoveInitMethodFromPageRepositoryRector.php
+++ b/src/Rector/Frontend/Page/RemoveInitMethodFromPageRepositoryRector.php
@@ -49,6 +49,9 @@ final class RemoveInitMethodFromPageRepositoryRector extends AbstractRector
         return null;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition('Remove method call init from PageRepository', [

--- a/src/Rector/Misc/AddCodeCoverageIgnoreToMethodRectorDefinitionRector.php
+++ b/src/Rector/Misc/AddCodeCoverageIgnoreToMethodRectorDefinitionRector.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Rector\Misc;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class AddCodeCoverageIgnoreToMethodRectorDefinitionRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isMethodStaticCallOrClassMethodObjectType($node, AbstractRector::class)) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'getDefinition')) {
+            return null;
+        }
+
+        /** @var PhpDocInfo $phpDocInfo */
+        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+
+        if ($phpDocInfo->hasByName('codeCoverageIgnore')) {
+            return null;
+        }
+
+        $phpDocInfo->addBareTag('codeCoverageIgnore');
+
+        return null;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Adds @codeCoverageIgnore annotation to to method getDefinition', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/Rector/v10/v4/UnifiedFileNameValidatorRector.php
+++ b/src/Rector/v10/v4/UnifiedFileNameValidatorRector.php
@@ -45,6 +45,9 @@ final class UnifiedFileNameValidatorRector extends AbstractRector
         return null;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition(

--- a/src/Rector/v9/v4/SystemEnvironmentBuilderConstantsRector.php
+++ b/src/Rector/v9/v4/SystemEnvironmentBuilderConstantsRector.php
@@ -83,6 +83,9 @@ final class SystemEnvironmentBuilderConstantsRector extends AbstractRector
         return $string;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition(

--- a/tests/Rector/Misc/AddCodeCoverageIgnoreToMethodRectorDefinitionRectorTest.php
+++ b/tests/Rector/Misc/AddCodeCoverageIgnoreToMethodRectorDefinitionRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\Misc;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Ssch\TYPO3Rector\Rector\Misc\AddCodeCoverageIgnoreToMethodRectorDefinitionRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AddCodeCoverageIgnoreToMethodRectorDefinitionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return AddCodeCoverageIgnoreToMethodRectorDefinitionRector::class;
+    }
+}

--- a/tests/Rector/Misc/Fixture/code_coverage_ignore.php.inc
+++ b/tests/Rector/Misc/Fixture/code_coverage_ignore.php.inc
@@ -1,0 +1,88 @@
+<?php
+
+use PhpParser\Node;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+final class AddToMissingCodeCoverageIgnore extends AbstractRector implements PhpRectorInterface
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}
+
+final class HasCodeCoverageIgnore extends AbstractRector implements PhpRectorInterface
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return RectorDefinition
+     */
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use PhpParser\Node;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+final class AddToMissingCodeCoverageIgnore extends AbstractRector implements PhpRectorInterface
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}
+
+final class HasCodeCoverageIgnore extends AbstractRector implements PhpRectorInterface
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return RectorDefinition
+     */
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}
+
+?>

--- a/utils/phpstan/config/typo3-rector.neon
+++ b/utils/phpstan/config/typo3-rector.neon
@@ -5,6 +5,11 @@ services:
             - phpstan.rules.rule
 
     -
+        class: Ssch\TYPO3Rector\PHPStan\Rules\AddCodeCoverageIgnoreForRectorDefinition
+        tags:
+            - phpstan.rules.rule
+
+    -
         class: Ssch\TYPO3Rector\PHPStan\Type\GeneralUtilityDynamicReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/utils/phpstan/tests/Rules/AddCodeCoverageIgnoreForRectorDefinition/AddCodeCoverageIgnoreForRectorDefinitionTest.php
+++ b/utils/phpstan/tests/Rules/AddCodeCoverageIgnoreForRectorDefinition/AddCodeCoverageIgnoreForRectorDefinitionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\PHPStan\Tests\Rules\AddCodeCoverageIgnoreForRectorDefinition;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Ssch\TYPO3Rector\PHPStan\Rules\AddCodeCoverageIgnoreForRectorDefinition;
+use Ssch\TYPO3Rector\PHPStan\Rules\AddSeeDocBlockForRectorClass;
+use Ssch\TYPO3Rector\PHPStan\Tests\Rules\AddCodeCoverageIgnoreForRectorDefinition\Fixture\MissingCodeCoverageIgnore;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+
+final class AddCodeCoverageIgnoreForRectorDefinitionTest extends AbstractServiceAwareRuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        $message = sprintf(AddCodeCoverageIgnoreForRectorDefinition::ERROR_MESSAGE, MissingCodeCoverageIgnore::class);
+        yield [__DIR__.'/Fixture/MissingCodeCoverageIgnore.php', [[$message, 22]]];
+        yield [__DIR__.'/Fixture/SkipWithCodeCoverageIgnore.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(AddCodeCoverageIgnoreForRectorDefinition::class, __DIR__.'/../../../config/typo3-rector.neon');
+    }
+}

--- a/utils/phpstan/tests/Rules/AddCodeCoverageIgnoreForRectorDefinition/Fixture/MissingCodeCoverageIgnore.php
+++ b/utils/phpstan/tests/Rules/AddCodeCoverageIgnoreForRectorDefinition/Fixture/MissingCodeCoverageIgnore.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\PHPStan\Tests\Rules\AddCodeCoverageIgnoreForRectorDefinition\Fixture;
+
+use PhpParser\Node;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+final class MissingCodeCoverageIgnore extends AbstractRector implements PhpRectorInterface
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}

--- a/utils/phpstan/tests/Rules/AddCodeCoverageIgnoreForRectorDefinition/Fixture/SkipWithCodeCoverageIgnore.php
+++ b/utils/phpstan/tests/Rules/AddCodeCoverageIgnoreForRectorDefinition/Fixture/SkipWithCodeCoverageIgnore.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\PHPStan\Tests\Rules\AddCodeCoverageIgnoreForRectorDefinition\Fixture;
+
+use PhpParser\Node;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+final class SkipWithCodeCoverageIgnore extends AbstractRector implements PhpRectorInterface
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDefinition(): RectorDefinition
+    {
+    }
+}

--- a/utils/phpstan/tests/Rules/AddSeeDocBlockForRectorClass/AddSeeDocBlockForRectorClassTest.php
+++ b/utils/phpstan/tests/Rules/AddSeeDocBlockForRectorClass/AddSeeDocBlockForRectorClassTest.php
@@ -10,9 +10,10 @@ use Ssch\TYPO3Rector\PHPStan\Rules\AddSeeDocBlockForRectorClass;
 use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
 
 final class AddSeeDocBlockForRectorClassTest extends AbstractServiceAwareRuleTestCase
-{ /**
- * @dataProvider provideData()
- */
+{
+    /**
+     * @dataProvider provideData()
+     */
     public function testRule(string $filePath, array $expectedErrorsWithLines): void
     {
         $this->analyse([$filePath], $expectedErrorsWithLines);
@@ -21,13 +22,12 @@ final class AddSeeDocBlockForRectorClassTest extends AbstractServiceAwareRuleTes
     public function provideData(): Iterator
     {
         $message = sprintf(AddSeeDocBlockForRectorClass::ERROR_MESSAGE, 'MissingSee');
-        yield [__DIR__ . '/Fixture/MissingSee.php', [[$message, 12]]];
-
-        yield [__DIR__ . '/Fixture/SkipWithSee.php', []];
+        yield [__DIR__.'/Fixture/MissingSee.php', [[$message, 12]]];
+        yield [__DIR__.'/Fixture/SkipWithSee.php', []];
     }
 
     protected function getRule(): Rule
     {
-        return $this->getRuleFromConfig( AddSeeDocBlockForRectorClass::class, __DIR__ . '/../../../config/typo3-rector.neon');
+        return $this->getRuleFromConfig(AddSeeDocBlockForRectorClass::class, __DIR__.'/../../../config/typo3-rector.neon');
     }
 }


### PR DESCRIPTION
For the method getDefinition we do not need a codeCoverage report. To ensure that, we add @codeCoverageIgnore docblock

Resolves: #1493