### PR TITLE
[TASK] Refactor GraphicalFunctions->prependAbsolutePath()

### DIFF
--- a/config/v8/typo3-80.php
+++ b/config/v8/typo3-80.php
@@ -8,6 +8,7 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameStaticMethod;
 use function Rector\SymfonyPhpConfig\inline_value_objects;
 use Ssch\TYPO3Rector\Rector\v8\v0\ChangeMethodCallsForStandaloneViewRector;
+use Ssch\TYPO3Rector\Rector\v8\v0\PrependAbsolutePathToGetFileAbsFileNameRector;
 use Ssch\TYPO3Rector\Rector\v8\v0\RefactorRemovedMarkerMethodsFromHtmlParserRector;
 use Ssch\TYPO3Rector\Rector\v8\v0\RefactorRemovedMethodsFromContentObjectRendererRector;
 use Ssch\TYPO3Rector\Rector\v8\v0\RefactorRemovedMethodsFromGeneralUtilityRector;
@@ -78,6 +79,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ],
         ]);
 
+    $services->set(PrependAbsolutePathToGetFileAbsFileNameRector::class);
     $services->set(RefactorRemovedMarkerMethodsFromHtmlParserRector::class);
     $services->set(RemoveRteHtmlParserEvalWriteFileRector::class);
 };

--- a/src/Rector/v8/v0/PrependAbsolutePathToGetFileAbsFileNameRector.php
+++ b/src/Rector/v8/v0/PrependAbsolutePathToGetFileAbsFileNameRector.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Rector\v8\v0;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @see https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.0/Deprecation-74022-GraphicalFunctions-prependAbsolutePath.html
+ */
+final class PrependAbsolutePathToGetFileAbsFileNameRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isMethodStaticCallOrClassMethodObjectType($node, GraphicalFunctions::class)) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'prependAbsolutePath')) {
+            return null;
+        }
+
+        return $this->createStaticCall(GeneralUtility::class, 'getFileAbsFileName', $node->args);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Use GeneralUtility::getFileAbsFileName() instead of GraphicalFunctions->prependAbsolutePath()',
+            [
+                new CodeSample(
+                    <<<'PHP'
+use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
+
+class SomeFooBar
+{
+    private $graphicalFunctions;
+
+    public function __construct(GraphicalFunctions $graphicalFunctions)
+    {
+        $this->graphicalFunctions = $graphicalFunctions;
+        $this->graphicalFunctions->prependAbsolutePath('some.font');
+    }
+}
+PHP
+                    ,
+                    <<<'PHP'
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
+
+class SomeFooBar
+{
+    private $graphicalFunctions;
+
+    public function __construct(GraphicalFunctions $graphicalFunctions)
+    {
+        $this->graphicalFunctions = $graphicalFunctions;
+        GeneralUtility::getFileAbsFileName('some.font');
+    }
+}
+PHP
+                ),
+
+            ]);
+    }
+}

--- a/src/Rector/v8/v0/RefactorRemovedMarkerMethodsFromHtmlParserRector.php
+++ b/src/Rector/v8/v0/RefactorRemovedMarkerMethodsFromHtmlParserRector.php
@@ -85,7 +85,7 @@ final class RefactorRemovedMarkerMethodsFromHtmlParserRector extends AbstractRec
         return new RectorDefinition('Refactor removed Marker-related methods from HtmlParser.', [
             new CodeSample(
                 <<<'PHP'
-se TYPO3\CMS\Core\Html\HtmlParser;
+use TYPO3\CMS\Core\Html\HtmlParser;
 
 final class HtmlParserMarkerRendererMethods
 {

--- a/stubs/Core/Imaging/GraphicalFunctions.php
+++ b/stubs/Core/Imaging/GraphicalFunctions.php
@@ -10,4 +10,8 @@ if (class_exists(GraphicalFunctions::class)) {
 
 final class GraphicalFunctions
 {
+    public function prependAbsolutePath($fontFile): void
+    {
+
+    }
 }

--- a/stubs/Core/Utility/GeneralUtility.php
+++ b/stubs/Core/Utility/GeneralUtility.php
@@ -111,4 +111,9 @@ class GeneralUtility
     {
 
     }
+
+    public static function getFileAbsFileName($filename): void
+    {
+
+    }
 }

--- a/tests/Rector/v8/v0/PrependAbsolutePathToGetFileAbsFileName/Fixture/prepend_absolute_path_to_get_file_abs_filename.php.inc
+++ b/tests/Rector/v8/v0/PrependAbsolutePathToGetFileAbsFileName/Fixture/prepend_absolute_path_to_get_file_abs_filename.php.inc
@@ -1,0 +1,54 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v0\PrependAbsolutePathToGetFileAbsFileName\Fixture;
+
+use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
+
+class SomeFooBar
+{
+    /**
+     * @var GraphicalFunctions
+     */
+    private $graphicalFunctions;
+
+    /**
+     * SomeFooBar constructor.
+     *
+     * @param GraphicalFunctions $graphicalFunctions
+     */
+    public function __construct(GraphicalFunctions $graphicalFunctions)
+    {
+        $this->graphicalFunctions = $graphicalFunctions;
+        $this->graphicalFunctions->prependAbsolutePath('some.font');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v0\PrependAbsolutePathToGetFileAbsFileName\Fixture;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
+
+class SomeFooBar
+{
+    /**
+     * @var GraphicalFunctions
+     */
+    private $graphicalFunctions;
+
+    /**
+     * SomeFooBar constructor.
+     *
+     * @param GraphicalFunctions $graphicalFunctions
+     */
+    public function __construct(GraphicalFunctions $graphicalFunctions)
+    {
+        $this->graphicalFunctions = $graphicalFunctions;
+        GeneralUtility::getFileAbsFileName('some.font');
+    }
+}
+
+?>

--- a/tests/Rector/v8/v0/PrependAbsolutePathToGetFileAbsFileName/PrependAbsolutePathToGetFileAbsFileNameRectorTest.php
+++ b/tests/Rector/v8/v0/PrependAbsolutePathToGetFileAbsFileName/PrependAbsolutePathToGetFileAbsFileNameRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v0\PrependAbsolutePathToGetFileAbsFileName;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Ssch\TYPO3Rector\Rector\v8\v0\PrependAbsolutePathToGetFileAbsFileNameRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class PrependAbsolutePathToGetFileAbsFileNameRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return PrependAbsolutePathToGetFileAbsFileNameRector::class;
+    }
+}


### PR DESCRIPTION
Use GeneralUtility::getFileAbsFileName() instead of GraphicalFunctions->prependAbsolutePath()

Resolves: #388