### PR TITLE
Fix configured path to typo3.constants.php

### DIFF
--- a/templates/rector.php.dist
+++ b/templates/rector.php.dist
@@ -48,9 +48,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // If you have trouble that rector cannot run because some TYPO3 constants are not defined add an additional constants file
     // Have a look at https://github.com/sabbelasichon/typo3-rector/blob/master/typo3.constants.php
-    $parameters->set(Option::AUTOLOAD_PATHS, [
-        __DIR__ . '/typo3.constants.php'
-    ]);
+    // $parameters->set(Option::AUTOLOAD_PATHS, [
+    //    __DIR__ . '/typo3.constants.php'
+    // ]);
 
     // get services (needed for register a single rule)
     // $services = $containerConfigurator->services();


### PR DESCRIPTION
The configured path to typo3.constants.php file is wrong.
It is now changed to expected location.
This already fixes the following issue for default setups.
Still if packages are installed somewhere else, the path would still be
wrong.

[ERROR] Could not process "*" file, due to:
        "File or directory 'typo3.constants.php' not found.".