### PR TITLE
Don't break if no none cacheable actions are configured

### DIFF
--- a/src/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModulesRector.php
+++ b/src/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModulesRector.php
@@ -151,12 +151,14 @@ PHP
         $controllerActions = $this->getValue($node->args[2]->value);
         $node->args[2]->value = $this->createNewControllerActionsArray($controllerActions, $vendorName, $extensionName);
 
-        $nonCacheableControllerActions = $this->getValue($node->args[3]->value);
-        $node->args[3]->value = $this->createNewControllerActionsArray(
-            $nonCacheableControllerActions,
-            $vendorName,
-            $extensionName
-        );
+        if (isset($node->args[3])) {
+            $nonCacheableControllerActions = $this->getValue($node->args[3]->value);
+            $node->args[3]->value = $this->createNewControllerActionsArray(
+                $nonCacheableControllerActions,
+                $vendorName,
+                $extensionName
+            );
+        }
     }
 
     private function refactorRegisterPluginMethod(StaticCall $node, string $vendorName, string $extensionName): void

--- a/tests/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModules/Fixture/refactor_configure_plugin.php.inc
+++ b/tests/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModules/Fixture/refactor_configure_plugin.php.inc
@@ -34,6 +34,14 @@ ExtensionUtility::configurePlugin(
     'ListView',
     [
         'Address' => 'list,show',
+    ]
+);
+
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+    'FriendsOfTYPO3.tt_address',
+    'ListView',
+    [
+        'Address' => 'list,show',
     ],
     [
         'Address' => '',
@@ -83,6 +91,12 @@ ExtensionUtility::configurePlugin(
     [FormFrontendController::class => 'render, perform'],
     [FormFrontendController::class => 'perform'],
     ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
+);
+
+ExtensionUtility::configurePlugin(
+    'TtAddress',
+    'ListView',
+    [\FriendsOfTYPO3\TtAddress\Controller\AddressController::class => 'list,show']
 );
 
 ExtensionUtility::configurePlugin(


### PR DESCRIPTION
Adjust code and add test scenario where optional third argument to
configure none cacheable actions is not provided.

As this was not checked beforehand, it would lead to this error:

[ERROR] Could not process "*" file by
        "Rector\Core\Rector\AbstractRector", due to:
        "Argument 1 passed to Rector\Core\Rector\AbstractRector::getValue() must be an instance of PhpParser\Node\Expr,
        null given, called in
        vendor/ssch/typo3-rector/src/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModulesRector.php:156".