### PR TITLE
Prevent possible duplicate constant definition

### DIFF
--- a/typo3.constants.php
+++ b/typo3.constants.php
@@ -39,7 +39,7 @@ define('PATH_thisScript', '');
 define('TYPO3_OS', '');
 define('PATH_typo3conf', '');
 define('PATH_typo3', '');
-define('TYPO3_COMPOSER_MODE', false);
+defined('TYPO3_COMPOSER_MODE') ?: define('TYPO3_COMPOSER_MODE', false);
 
 define('TYPO3_URL_MAILINGLISTS', 'http://lists.typo3.org/cgi-bin/mailman/listinfo');
 define('TYPO3_URL_DOCUMENTATION', 'https://typo3.org/documentation/');


### PR DESCRIPTION
Under some circumstances it might happen that TYPO3_COMPOSER_MODE is
already defined.
This change fixes the following notice:

Notice: Constant TYPO3_COMPOSER_MODE already defined in
/vendor/ssch/typo3-rector/typo3.constants.php on line 42