### PR TITLE
Override child tca

### DIFF
--- a/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/foreign_record_defaults.php.inc
+++ b/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/foreign_record_defaults.php.inc
@@ -1,0 +1,31 @@
+<?php
+return [
+'ctrl' => [
+],
+    'columns' => [
+        'aField' => [
+            'config' => [
+                'type' => 'inline',
+                'foreign_record_defaults' => [
+                    'aChildField' => 42,
+                ],
+            ],
+        ],
+    ],
+];
+?>
+-----
+<?php
+return [
+'ctrl' => [
+],
+    'columns' => [
+        'aField' => [
+            'config' => [
+                'type' => 'inline',
+                'overrideChildTca' => ['columns' => ['aChildField' => ['config' => ['default' => 42]]]],
+            ],
+        ],
+    ],
+];
+?>

--- a/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/foreign_selector_fieldTcaOverride.php.inc
+++ b/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/foreign_selector_fieldTcaOverride.php.inc
@@ -1,0 +1,69 @@
+<?php
+return [
+'ctrl' => [
+],
+    'columns' => [
+        'aField' => [
+            'config' => [
+                'type' => 'inline',
+                'foreign_selector' => 'uid_local',
+                'foreign_selector_fieldTcaOverride' => [
+                    'config' => [
+                        'appearance' => [
+                            'elementBrowserType' => 'file',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'bField' => [
+            'config' => [
+                'type' => 'inline',
+                'foreign_selector' => 'uid_remote',
+                'foreign_selector_fieldTcaOverride' => [
+                    'config' => [
+                        'appearance' => [
+                            'elementBrowserType' => 'file',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+];
+?>
+-----
+<?php
+return [
+'ctrl' => [
+],
+    'columns' => [
+        'aField' => [
+            'config' => [
+                'type' => 'inline',
+                'foreign_selector' => 'uid_local',
+                'overrideChildTca' => ['columns' => ['uid_local' => [
+                    'config' => [
+                        'appearance' => [
+                            'elementBrowserType' => 'file',
+                        ],
+                    ],
+                ]]],
+            ],
+        ],
+        'bField' => [
+            'config' => [
+                'type' => 'inline',
+                'foreign_selector' => 'uid_remote',
+                'overrideChildTca' => ['columns' => ['uid_remote' => [
+                    'config' => [
+                        'appearance' => [
+                            'elementBrowserType' => 'file',
+                        ],
+                    ],
+                ]]],
+            ],
+        ],
+    ],
+];
+?>

--- a/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/withExtensionManagementUtilityGetFileFieldTcaConfig.php.inc
+++ b/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/withExtensionManagementUtilityGetFileFieldTcaConfig.php.inc
@@ -58,7 +58,6 @@ return [
 ?>
 -----
 <?php
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 $xlf = 'LLL:EXT:...';
 return [
     'ctrl' => [
@@ -91,7 +90,7 @@ return [
         'files' => [
             'exclude' => true,
             'label' => $xlf . 'files',
-            'config' => ExtensionManagementUtility::getFileFieldTCAConfig(
+            'config' => TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
                 'files',
                 [
                     'appearance' => [

--- a/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/withExtensionManagementUtilityGetFileFieldTcaConfig.php.inc
+++ b/tests/Rector/v8/v7/MoveForeignTypesToOverrideChildTca/Fixture/withExtensionManagementUtilityGetFileFieldTcaConfig.php.inc
@@ -58,6 +58,7 @@ return [
 ?>
 -----
 <?php
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 $xlf = 'LLL:EXT:...';
 return [
     'ctrl' => [
@@ -90,7 +91,7 @@ return [
         'files' => [
             'exclude' => true,
             'label' => $xlf . 'files',
-            'config' => TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig(
                 'files',
                 [
                     'appearance' => [


### PR DESCRIPTION
Following the slack discussion, two additonal cases of https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.7/Deprecation-80000-InlineOverrideChildTca.html are handled by the alredy existing rector