### PR TITLE
[BUGFIX] Preserve formatting of TCA when no changes are necessary

### DIFF
--- a/src/Rector/v7/v4/DropAdditionalPaletteRector.php
+++ b/src/Rector/v7/v4/DropAdditionalPaletteRector.php
@@ -124,6 +124,10 @@ final class DropAdditionalPaletteRector extends AbstractRector
                         $newFieldStrings[] = $fieldString;
                     }
                 }
+                if ($newFieldStrings === $itemList) {
+                    // do not alter the syntax tree, if there are no changes. This will keep formatting of the code intact
+                    continue;
+                }
                 $typeItem->value = new String_(implode(',', $newFieldStrings));
             }
         }

--- a/tests/Rector/v7/v4/DropAdditionalPalette/Fixture/no_change_without_additional_palette.php.inc
+++ b/tests/Rector/v7/v4/DropAdditionalPalette/Fixture/no_change_without_additional_palette.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v7\v4\DropAdditionalPalette\Fixture;
+
+return [
+    'ctrl' => [
+    ],
+    'types' => [
+        'aType' => [
+            'showitem' => 'aField;aLabel, aField;aLabel',
+        ],
+    ],
+    'columns' => [
+    ],
+];
+
+?>


### PR DESCRIPTION
if no changes to the syntax tree are necessary, we should not alter it, to preserve the code formatting.

this reduces noise in rector output and git logs