### PR TITLE
[FEATURE] Migrate ObjectManager->get() to GeneralUtility::makeInstance()

### DIFF
--- a/config/v10/typo3-104.php
+++ b/config/v10/typo3-104.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Rector\Renaming\Rector\StaticCall\RenameStaticMethodRector;
 use Rector\Renaming\ValueObject\RenameStaticMethod;
+use Rector\Transform\Rector\MethodCall\MethodCallToStaticCallRector;
+use Rector\Transform\ValueObject\MethodCallToStaticCall;
 use Ssch\TYPO3Rector\Rector\Migrations\RenameClassMapAliasRector;
 use Ssch\TYPO3Rector\Rector\v10\v4\SubstituteGeneralUtilityMethodsWithNativePhpFunctionsRector;
 use Ssch\TYPO3Rector\Rector\v10\v4\UnifiedFileNameValidatorRector;
@@ -42,4 +44,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ],
         ]]);
     $services->set(UseFileGetContentsForGetUrlRector::class);
+    $services->set('typo3_objectmanagerget_to_generalutilitymakeinstance')
+        ->class(MethodCallToStaticCallRector::class)
+        ->call('configure', [[
+            MethodCallToStaticCallRector::METHOD_CALLS_TO_STATIC_CALLS => ValueObjectInliner::inline([
+                new MethodCallToStaticCall(
+                    \TYPO3\CMS\Extbase\Object\ObjectManagerInterface::class,
+                    'get',
+                    \TYPO3\CMS\Core\Utility\GeneralUtility::class,
+                    'makeInstance'
+                ),
+            ]),
+        ]]);
 };

--- a/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/Fixture/substitute_objectmanager_get.php.inc
+++ b/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/Fixture/substitute_objectmanager_get.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+class SubstituteObjetManagerTemp
+{
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    public function example()
+    {
+        $service = $this->objectManager->get(Service::class);
+    }
+}
+
+?>
+-----
+<?php
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+class SubstituteObjetManagerTemp
+{
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    public function example()
+    {
+        $service = GeneralUtility::makeInstance(Service::class);
+    }
+}
+
+?>

--- a/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/Fixture/substitute_objectmanagerinterface_get.php.inc
+++ b/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/Fixture/substitute_objectmanagerinterface_get.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+
+class SubstituteObjetManagerInterfaceTemp
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    public function example()
+    {
+        $service = $this->objectManager->get(Service::class);
+    }
+}
+
+?>
+-----
+<?php
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+
+class SubstituteObjetManagerInterfaceTemp
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    public function example()
+    {
+        $service = GeneralUtility::makeInstance(Service::class);
+    }
+}
+
+?>

--- a/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRectorTest.php
+++ b/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v10\v4\SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractCommunityRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRectorTest extends AbstractCommunityRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/config/configured_rule.php
+++ b/tests/Rector/v10/v4/SubstituteObjectManagerGetWithGeneralUtilityMakeInstanceRector/config/configured_rule.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Transform\Rector\MethodCall\MethodCallToStaticCallRector;
+use Rector\Transform\ValueObject\MethodCallToStaticCall;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../../config/services.php');
+
+    $services = $containerConfigurator->services();
+    $services->set('typo3_objectmanagerget_to_generalutilitymakeinstance')
+        ->class(MethodCallToStaticCallRector::class)
+        ->call('configure', [[
+            MethodCallToStaticCallRector::METHOD_CALLS_TO_STATIC_CALLS => ValueObjectInliner::inline([
+                new MethodCallToStaticCall(
+                    \TYPO3\CMS\Extbase\Object\ObjectManagerInterface::class,
+                    'get',
+                    \TYPO3\CMS\Core\Utility\GeneralUtility::class,
+                    'makeInstance'
+                ),
+            ]),
+        ]]);
+};


### PR DESCRIPTION
This migration assumes developers already migrated to dependency
injection where possible and useful.
All existing calls will be migrated.
In order to have proper working code, a Services.yaml is necessary.

Relates: #1883