### PR TITLE
[BUGFIX] Correct nested array of service configuration call

### DIFF
--- a/config/v10/typo3-100.php
+++ b/config/v10/typo3-100.php
@@ -28,11 +28,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     )
         ->call(
         'configure',
-        [
-            RenameNamespaceRector::OLD_TO_NEW_NAMESPACES => [[
+        [[
+            RenameNamespaceRector::OLD_TO_NEW_NAMESPACES => [
                 'TYPO3\CMS\Backend\Controller\File' => 'TYPO3\CMS\Filelist\Controller\File',
-            ]],
-        ]
+            ],
+        ]]
     );
     $services->set(UseMetaDataAspectRector::class);
     $services->set(ForceTemplateParsingInTsfeAndTemplateServiceRector::class);


### PR DESCRIPTION
## Setup

* `ssch/typo3-rector`: 0.9.0
* `rector/rector`: 0.9.26
* PHP: 7.4.13

## Problem

Version 0.9.0 contains an issue regarding nested array configuration of the service `rename_namespace_backend_controller_file_to_filelist_controller_file`. This PR solves the issue by defining the properly nested array.

## Steps to reproduce

1. Install Rector:
   ```bash
   composer req --dev ssch/typo3-rector:0.9.0
   ```

2. Add set `Typo3SetList::TYPO3_104` in generated `rector.php`:
   ```php
   $parameters->set(Option::SETS, [
       Typo3SetList::TYPO3_95,
       Typo3SetList::TYPO3_104,
   ]);
   ```
3. Run Rector:
   ```bash
   vendor/bin/typo3-rector process
   ```

Now you should see the following error:

```
 [ERROR] Invalid service "rename_namespace_backend_controller_file_to_filelist_controller_file": method                 
         "Rector\Renaming\Rector\Namespace_\RenameNamespaceRector::configure()" has no argument named                   
         "$oldToNewNamespaces". Check your service definition.
```