### PR TITLE
do not build scoped version on PR

### DIFF
--- a/.github/workflows/build_scoped_typo3_rector.yaml
+++ b/.github/workflows/build_scoped_typo3_rector.yaml
@@ -1,8 +1,6 @@
 name: Build Scoped TYPO3 Rector
 
 on:
-    pull_request: null
-
     push:
         # see https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/10?u=tomasvotruba
         branches:


### PR DESCRIPTION
This addresses previously mentioned issue, when scoped version is build on PR. It should happen on merge to master or release