### PR TITLE
Refactor TCA handling to a column-wise approach that enables Tca/Overrides handling

### DIFF
--- a/src/Helper/TcaHelperTrait.php
+++ b/src/Helper/TcaHelperTrait.php
@@ -110,6 +110,16 @@ trait TcaHelperTrait
         return $columnItems;
     }
 
+    private function extractArrayValueByKey(?Node $node, string $key): ?Expr
+    {
+        $item = $this->extractArrayItemByKey($node, $key);
+        if (null === $item || null === $item->value) {
+            return null;
+        }
+
+        return $item->value;
+    }
+
     /**
      * @return Generator<ArrayItem>
      */

--- a/src/Helper/TcaHelperTrait.php
+++ b/src/Helper/TcaHelperTrait.php
@@ -19,7 +19,7 @@ trait TcaHelperTrait
      */
     protected $valueResolver;
 
-    private function isTca(Return_ $node): bool
+    private function isFullTca(Return_ $node): bool
     {
         $ctrl = $this->extractCtrl($node);
         $columns = $this->extractColumns($node);

--- a/src/Helper/TcaHelperTrait.php
+++ b/src/Helper/TcaHelperTrait.php
@@ -9,9 +9,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
-use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Return_;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 
 trait TcaHelperTrait
@@ -93,7 +91,7 @@ trait TcaHelperTrait
         return null;
     }
 
-    private function extractSubArrayByKey(?Node $node, string $key, bool $throwException = false): ?Array_
+    private function extractSubArrayByKey(?Node $node, string $key): ?Array_
     {
         if (null === $node) {
             return null;
@@ -105,11 +103,6 @@ trait TcaHelperTrait
         }
 
         $columnItems = $arrayItem->value;
-
-        if ($columnItems instanceof StaticCall && $throwException) {
-            throw new ShouldNotHappenException('ColumnItems is of type StaticCall');
-        }
-
         if (! $columnItems instanceof Array_) {
             return null;
         }

--- a/src/Rector/Tca/AbstractColumnwiseTcaRector.php
+++ b/src/Rector/Tca/AbstractColumnwiseTcaRector.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Rector\Tca;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use Rector\Core\Rector\AbstractRector;
+use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
+
+/**
+ * @changelog
+ */
+abstract class AbstractColumnwiseTcaRector extends AbstractRector
+{
+    use TcaHelperTrait;
+
+    /**
+     * @var string
+     */
+    protected const TYPE = 'type';
+
+    /**
+     * @var bool
+     */
+    protected $hasAstBeenChanged = false;
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Array_::class];
+    }
+
+    /**
+     * @param Array_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof Array_) {
+            return null;
+        }
+
+        $this->hasAstBeenChanged = false;
+        if ($this->isFullTcaDefinition($node)) {
+            $columns = $this->extractSubArrayByKey($node, 'columns');
+            if (null !== $columns) {
+                // we found a tca definition of a full table. Process it as a whole:
+                $this->refactorColumnList($columns);
+                return $this->hasAstBeenChanged ? $node : null;
+            }
+        }
+
+        // this is not a full tca definition. Lets check some fuzzier stuff.
+        // it could be a list of columns, as in ExtensionManagementUtility::addTcaColums('table', $node)
+        foreach ($node->items as $arrayItem) {
+            if (! $arrayItem instanceof ArrayItem) {
+                // lets play it safe here. a non-associative array is probably not tca.
+                continue;
+            }
+
+            if (! $arrayItem->key instanceof String_) {
+                // the key of a column list in tca is the column name, which needs to be a string.
+                continue;
+            }
+
+            if ($arrayItem->value instanceof Array_) {
+                // we found a single column configuration which is an array
+                // (not a call to stuff like ExtensionManagementUtility::getFileFieldTCAConfig)
+                if ($this->isSingleTcaColumn($arrayItem)) {
+                    $this->refactorColumn($arrayItem->key, $arrayItem->value);
+                }
+            }
+        }
+
+        return $this->hasAstBeenChanged ? $node : null;
+    }
+
+    /**
+     * refactors an TCA array such as [ 'column_1' => [ 'label' => 'column 1', 'config' => ... ], 'column_2' => [
+     * 'label' => 'column 2', 'config' => ... ] ]
+     *
+     * @param Array_ $columns a list of TCA definitions for columns
+     */
+    protected function refactorColumnList(Array_ $columns): void
+    {
+        foreach ($columns->items as $columnArrayItem) {
+            if (! $columnArrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            $columnName = $columnArrayItem->key;
+            if (null === $columnName) {
+                continue;
+            }
+
+            $columnTca = $columnArrayItem->value;
+
+            $this->refactorColumn($columnName, $columnTca);
+        }
+    }
+
+    /**
+     * @return bool whether or not the given Array_ is a full TCA definition for a Table
+     */
+    protected function isFullTcaDefinition(Array_ $possibleTcaArray): bool
+    {
+        $columns = $this->extractSubArrayByKey($possibleTcaArray, 'columns');
+        $ctrl = $this->extractArrayItemByKey($possibleTcaArray, 'ctrl');
+
+        return null !== $columns && null !== $ctrl;
+    }
+
+    /**
+     * @return bool whether the given array item is the TCA definition of a single column
+     */
+    protected function isSingleTcaColumn(ArrayItem $arrayItem): bool
+    {
+        $labelNode = $this->extractArrayItemByKey($arrayItem->value, 'label');
+        $typeNode = $this->extractArrayItemByKey($arrayItem->value, 'type');
+        return null !== $labelNode && null !== $typeNode;
+    }
+
+    /**
+     * Refactors a single TCA column definition like 'column_name' => [ 'label' => 'column label', 'config' => [], ]
+     *
+     * remark: checking if the passed nodes really are a TCA snippet must be checked by the caller.
+     *
+     * @param Expr $columnName the key in above example (typically String_('column_name'))
+     * @param Expr $columnTca the value in above example (typically an associative Array with stuff like 'label', 'config', 'exclude', ...)
+     */
+    abstract protected function refactorColumn(Expr $columnName, Expr $columnTca): void;
+}

--- a/src/Rector/Tca/AbstractColumnwiseTcaRector.php
+++ b/src/Rector/Tca/AbstractColumnwiseTcaRector.php
@@ -40,10 +40,6 @@ abstract class AbstractColumnwiseTcaRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node instanceof Array_) {
-            return null;
-        }
-
         $this->hasAstBeenChanged = false;
         if ($this->isFullTcaDefinition($node)) {
             $columns = $this->extractSubArrayByKey($node, 'columns');
@@ -67,12 +63,10 @@ abstract class AbstractColumnwiseTcaRector extends AbstractRector
                 continue;
             }
 
-            if ($arrayItem->value instanceof Array_) {
-                // we found a single column configuration which is an array
-                // (not a call to stuff like ExtensionManagementUtility::getFileFieldTCAConfig)
-                if ($this->isSingleTcaColumn($arrayItem)) {
-                    $this->refactorColumn($arrayItem->key, $arrayItem->value);
-                }
+            // we found a single column configuration which is an array
+            // (not a call to stuff like ExtensionManagementUtility::getFileFieldTCAConfig)
+            if ($arrayItem->value instanceof Array_ && $this->isSingleTcaColumn($arrayItem)) {
+                $this->refactorColumn($arrayItem->key, $arrayItem->value);
             }
         }
 

--- a/src/Rector/Tca/AbstractTcaRector.php
+++ b/src/Rector/Tca/AbstractTcaRector.php
@@ -12,7 +12,7 @@ use Rector\Core\Rector\AbstractRector;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
 
 /**
- * @changelog
+ * Base rector that detects Arrays containing TCA definitions and allows to refactor them
  */
 abstract class AbstractTcaRector extends AbstractRector
 {

--- a/src/Rector/Tca/AbstractTcaRector.php
+++ b/src/Rector/Tca/AbstractTcaRector.php
@@ -13,7 +13,7 @@ use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
 /**
  * @changelog
  */
-abstract class AbstractColumnwiseTcaRector extends AbstractRector
+abstract class AbstractTcaRector extends AbstractRector
 {
     use TcaHelperTrait;
 
@@ -21,6 +21,14 @@ abstract class AbstractColumnwiseTcaRector extends AbstractRector
      * @var string
      */
     protected const TYPE = 'type';
+    /**
+     * @var string
+     */
+    protected const CONFIG = 'config';
+    /**
+     * @var string
+     */
+    protected const LABEL = 'label';
 
     /**
      * @var bool
@@ -113,9 +121,18 @@ abstract class AbstractColumnwiseTcaRector extends AbstractRector
      */
     protected function isSingleTcaColumn(ArrayItem $arrayItem): bool
     {
-        $labelNode = $this->extractArrayItemByKey($arrayItem->value, 'label');
-        $typeNode = $this->extractArrayItemByKey($arrayItem->value, 'type');
-        return null !== $labelNode && null !== $typeNode;
+        $labelNode = $this->extractArrayItemByKey($arrayItem->value, self::LABEL);
+        if (null === $labelNode) {
+            return false;
+        }
+
+        $configNode = $this->extractArrayItemByKey($arrayItem->value, self::CONFIG);
+        if (null === $configNode) {
+            return false;
+        }
+
+        $typeNode = $this->extractArrayItemByKey($configNode->value, self::TYPE);
+        return null !== $typeNode;
     }
 
     /**

--- a/src/Rector/Tca/AbstractTcaRector.php
+++ b/src/Rector/Tca/AbstractTcaRector.php
@@ -21,10 +21,12 @@ abstract class AbstractTcaRector extends AbstractRector
      * @var string
      */
     protected const TYPE = 'type';
+
     /**
      * @var string
      */
     protected const CONFIG = 'config';
+
     /**
      * @var string
      */
@@ -144,4 +146,24 @@ abstract class AbstractTcaRector extends AbstractRector
      * @param Expr $columnTca the value in above example (typically an associative Array with stuff like 'label', 'config', 'exclude', ...)
      */
     abstract protected function refactorColumn(Expr $columnName, Expr $columnTca): void;
+
+    /**
+     * @param Array_ $array An array into which a new ArrayItem should be inserted
+     * @param ArrayItem $newItem The item to be inserted
+     * @param string $key The key after which the ArrayItem should be inserted
+     */
+    protected function insertItemAfterKey(Array_ $array, ArrayItem $newItem, string $key): void
+    {
+        $positionOfTypeInConfig = 0;
+        foreach ($array->items as $configNode) {
+            if (null === $configNode) {
+                break;
+            }
+            if (null === $configNode->key || $this->valueResolver->getValue($configNode->key) === $key) {
+                break;
+            }
+            $positionOfTypeInConfig++;
+        }
+        array_splice($array->items, $positionOfTypeInConfig + 1, 0, [$newItem]);
+    }
 }

--- a/src/Rector/Tca/AbstractTcaRector.php
+++ b/src/Rector/Tca/AbstractTcaRector.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
+use Rector\Core\Console\Output\RectorOutputStyle;
 use Rector\Core\Rector\AbstractRector;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
 
@@ -33,9 +34,19 @@ abstract class AbstractTcaRector extends AbstractRector
     protected const LABEL = 'label';
 
     /**
+     * @var RectorOutputStyle
+     */
+    protected $rectorOutputStyle;
+
+    /**
      * @var bool
      */
     protected $hasAstBeenChanged = false;
+
+    public function __construct(RectorOutputStyle $rectorOutputStyle)
+    {
+        $this->rectorOutputStyle = $rectorOutputStyle;
+    }
 
     /**
      * @return array<class-string<Node>>

--- a/src/Rector/v10/v0/RemoveSeliconFieldPathRector.php
+++ b/src/Rector/v10/v0/RemoveSeliconFieldPathRector.php
@@ -59,7 +59,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v10/v0/RemoveTcaOptionSetToDefaultOnCopyRector.php
+++ b/src/Rector/v10/v0/RemoveTcaOptionSetToDefaultOnCopyRector.php
@@ -63,7 +63,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v10/v3/RemoveExcludeOnTransOrigPointerFieldRector.php
+++ b/src/Rector/v10/v3/RemoveExcludeOnTransOrigPointerFieldRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v10/v3/RemoveShowRecordFieldListInsideInterfaceSectionRector.php
+++ b/src/Rector/v10/v3/RemoveShowRecordFieldListInsideInterfaceSectionRector.php
@@ -65,7 +65,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v7/v0/RemoveDivider2TabsConfigurationRector.php
+++ b/src/Rector/v7/v0/RemoveDivider2TabsConfigurationRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v7/v4/DropAdditionalPaletteRector.php
+++ b/src/Rector/v7/v4/DropAdditionalPaletteRector.php
@@ -51,7 +51,7 @@ final class DropAdditionalPaletteRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v7/v5/RemoveIconsInOptionTagsRector.php
+++ b/src/Rector/v7/v5/RemoveIconsInOptionTagsRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v7/v5/UseExtPrefixForTcaIconFileRector.php
+++ b/src/Rector/v7/v5/UseExtPrefixForTcaIconFileRector.php
@@ -68,7 +68,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v7/v6/AddRenderTypeToSelectFieldRector.php
+++ b/src/Rector/v7/v6/AddRenderTypeToSelectFieldRector.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Ssch\TYPO3Rector\Rector\v7\v6;
 
-use PhpParser\Node;
-use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\Stmt\Return_;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\Rector\AbstractRector;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
+use Ssch\TYPO3Rector\Rector\Tca\AbstractTcaRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/7.6/Deprecation-69822-DeprecateSelectFieldTca.html
  * @see \Ssch\TYPO3Rector\Tests\Rector\v7\v6\AddRenderTypeToSelectFieldRector\AddRenderTypeToSelectFieldRectorTest
  */
-final class AddRenderTypeToSelectFieldRector extends AbstractRector
+final class AddRenderTypeToSelectFieldRector extends AbstractTcaRector
 {
     use TcaHelperTrait;
 
@@ -69,135 +67,50 @@ CODE_SAMPLE
         ]);
     }
 
-    /**
-     * @return array<class-string<Node>>
-     */
-    public function getNodeTypes(): array
+    protected function refactorColumn(Expr $columnName, Expr $columnTca): void
     {
-        return [Return_::class];
-    }
-
-    /**
-     * @param Return_ $node
-     */
-    public function refactor(Node $node): ?Node
-    {
-        if (! $this->isFullTca($node)) {
-            return null;
+        $config = $this->extractSubArrayByKey($columnTca, 'config');
+        if (null === $config) {
+            return;
         }
 
-        $columns = $this->extractColumns($node);
-
-        if (! $columns instanceof ArrayItem) {
-            return null;
+        if (! $this->hasKeyValuePair($config, self::TYPE, 'select')) {
+            return;
         }
 
-        $items = $columns->value;
-
-        if (! $items instanceof Array_) {
-            return null;
+        if (null !== $this->extractArrayItemByKey($config, self::RENDER_TYPE)) {
+            // If the renderType is already set, do nothing
+            return;
         }
 
-        $hasAstBeenChanged = false;
+        $renderModeExpr = $this->extractArrayValueByKey($config, 'renderMode');
+        if (null !== $renderModeExpr) {
+            $renderType = null;
 
-        foreach ($items->items as $fieldValue) {
-            if (! $fieldValue instanceof ArrayItem) {
-                continue;
+            if ($this->isValue($renderModeExpr, 'tree')) {
+                $renderType = 'selectTree';
+            } elseif ($this->valueResolver->isValue($renderModeExpr, 'singlebox')) {
+                $renderType = 'selectSingleBox';
+            } elseif ($this->valueResolver->isValue($renderModeExpr, 'checkbox')) {
+                $renderType = 'selectCheckBox';
+            } else {
+                // ToDo: report this case instead of failing
+                new ShouldNotHappenException(sprintf(
+                    'The render mode %s is invalid for the select field in %s',
+                    $this->valueResolver->getValue($renderModeExpr),
+                    $this->valueResolver->getValue($columnName)
+                ));
             }
-
-            if (null === $fieldValue->key) {
-                continue;
-            }
-
-            $fieldName = $this->valueResolver->getValue($fieldValue->key);
-
-            if (null === $fieldName) {
-                continue;
-            }
-
-            if (! $fieldValue->value instanceof Array_) {
-                continue;
-            }
-
-            foreach ($fieldValue->value->items as $configValue) {
-                if (null === $configValue) {
-                    continue;
-                }
-
-                if (! $configValue->value instanceof Array_) {
-                    continue;
-                }
-
-                $configType = null;
-                $renderMode = null;
-                $maxItems = 1;
-                $renderType = null;
-                foreach ($configValue->value->items as $configItemValue) {
-                    if (! $configItemValue instanceof ArrayItem) {
-                        continue;
-                    }
-
-                    if (null === $configItemValue->key) {
-                        continue;
-                    }
-
-                    if ($this->valueResolver->isValue($configItemValue->key, 'type')) {
-                        $configType = $this->valueResolver->getValue($configItemValue->value);
-                    } elseif ($this->valueResolver->isValue($configItemValue->key, 'renderMode')) {
-                        $renderMode = $this->valueResolver->getValue($configItemValue->value);
-                    } elseif ($this->valueResolver->isValue($configItemValue->key, 'maxitems')) {
-                        $maxItems = $this->valueResolver->getValue($configItemValue->value);
-                    } elseif ($this->valueResolver->isValue($configItemValue->key, self::RENDER_TYPE)) {
-                        $renderType = $this->valueResolver->getValue($configItemValue->value);
-                    }
-                }
-
-                if ('select' !== $configType) {
-                    continue;
-                }
-
-                // If the renderType is already set, do nothing
-                if (null !== $renderType) {
-                    continue;
-                }
-
-                if (null !== $renderMode) {
-                    $renderType = null;
-
-                    if ('tree' === $renderMode) {
-                        $renderType = 'selectTree';
-                    } elseif ('singlebox' === $renderMode) {
-                        $renderType = 'selectSingleBox';
-                    } elseif ('checkbox' === $renderMode) {
-                        $renderType = 'selectCheckBox';
-                    } else {
-                        new ShouldNotHappenException(sprintf(
-                            'The render mode %s is invalid for the select field in %s',
-                            $renderMode,
-                            $fieldName
-                        ));
-                    }
-
-                    if (null !== $renderType) {
-                        $configValue->value->items[] = new ArrayItem(new String_($renderType), new String_(
-                            self::RENDER_TYPE
-                        ));
-                        $hasAstBeenChanged = true;
-                    }
-
-                    continue;
-                }
-
-                $renderType = $maxItems <= 1 ? 'selectSingle' : 'selectMultipleSideBySide';
-
-                if (null !== $renderType) {
-                    $configValue->value->items[] = new ArrayItem(new String_($renderType), new String_(
-                        self::RENDER_TYPE
-                    ));
-                    $hasAstBeenChanged = true;
-                }
-            }
+        } else {
+            $maxItemsExpr = $this->extractArrayValueByKey($config, 'maxitems');
+            $maxItems = null !== $maxItemsExpr ? $this->valueResolver->getValue($maxItemsExpr) : null;
+            $renderType = $maxItems <= 1 ? 'selectSingle' : 'selectMultipleSideBySide';
         }
-        return $hasAstBeenChanged ? $node : null;
+
+        if (null !== $renderType) {
+            $renderTypeItem = new ArrayItem(new String_($renderType), new String_(self::RENDER_TYPE));
+            $this->insertItemAfterKey($config, $renderTypeItem, self::TYPE);
+            $this->hasAstBeenChanged = true;
+        }
     }
 }

--- a/src/Rector/v7/v6/AddRenderTypeToSelectFieldRector.php
+++ b/src/Rector/v7/v6/AddRenderTypeToSelectFieldRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v7/v6/AddRenderTypeToSelectFieldRector.php
+++ b/src/Rector/v7/v6/AddRenderTypeToSelectFieldRector.php
@@ -7,7 +7,6 @@ namespace Ssch\TYPO3Rector\Rector\v7\v6;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
 use Ssch\TYPO3Rector\Rector\Tca\AbstractTcaRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -94,12 +93,14 @@ CODE_SAMPLE
             } elseif ($this->valueResolver->isValue($renderModeExpr, 'checkbox')) {
                 $renderType = 'selectCheckBox';
             } else {
-                // ToDo: report this case instead of failing
-                new ShouldNotHappenException(sprintf(
-                    'The render mode %s is invalid for the select field in %s',
-                    $this->valueResolver->getValue($renderModeExpr),
-                    $this->valueResolver->getValue($columnName)
-                ));
+                $this->rectorOutputStyle->warning(
+                    sprintf(
+                        'The render mode %s is invalid for the select field in %s',
+                        $this->valueResolver->getValue($renderModeExpr),
+                        $this->valueResolver->getValue($columnName)
+                    )
+                );
+                return;
             }
         } else {
             $maxItemsExpr = $this->extractArrayValueByKey($config, 'maxitems');

--- a/src/Rector/v7/v6/MigrateT3editorWizardToRenderTypeT3editorRector.php
+++ b/src/Rector/v7/v6/MigrateT3editorWizardToRenderTypeT3editorRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v7/v6/RemoveIconOptionForRenderTypeSelectRector.php
+++ b/src/Rector/v7/v6/RemoveIconOptionForRenderTypeSelectRector.php
@@ -78,7 +78,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v3/RemovedTcaSelectTreeOptionsRector.php
+++ b/src/Rector/v8/v3/RemovedTcaSelectTreeOptionsRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v3/SoftReferencesFunctionalityRemovedRector.php
+++ b/src/Rector/v8/v3/SoftReferencesFunctionalityRemovedRector.php
@@ -36,7 +36,7 @@ final class SoftReferencesFunctionalityRemovedRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v4/RemoveOptionShowIfRteRector.php
+++ b/src/Rector/v8/v4/RemoveOptionShowIfRteRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v4/SubstituteOldWizardIconsRector.php
+++ b/src/Rector/v8/v4/SubstituteOldWizardIconsRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v5/RemoveOptionVersioningFollowPagesRector.php
+++ b/src/Rector/v8/v5/RemoveOptionVersioningFollowPagesRector.php
@@ -63,7 +63,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v5/RemoveSupportForTransForeignTableRector.php
+++ b/src/Rector/v8/v5/RemoveSupportForTransForeignTableRector.php
@@ -34,7 +34,7 @@ final class RemoveSupportForTransForeignTableRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
+++ b/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Return_;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -66,10 +65,14 @@ final class AddTypeToColumnConfigRector extends AbstractRector
                 continue;
             }
 
-            try {
-                $config = $this->extractSubArrayByKey($columnArrayItem->value, 'config', true);
-            } catch (ShouldNotHappenException $shouldNotHappenException) {
-                continue;
+            $config = null;
+            $configItem = $this->extractArrayItemByKey($columnArrayItem->value, 'config');
+
+            if (null !== $configItem) {
+                $config = $configItem->value;
+                if (! $config instanceof  Array_) {
+                    continue;
+                }
             }
 
             if (null === $config) {

--- a/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
+++ b/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector\Rector\v8\v6;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Type\ObjectType;
@@ -34,7 +38,7 @@ final class AddTypeToColumnConfigRector extends AbstractRector
      */
     public function getNodeTypes(): array
     {
-        return [Return_::class, Node\Expr\StaticCall::class];
+        return [Return_::class, StaticCall::class];
     }
 
     /**
@@ -78,7 +82,7 @@ CODE_SAMPLE
         )]);
     }
 
-    private function refactorColumn(Node\Expr $columnName, Node\Expr $columnTca): bool
+    private function refactorColumn(Expr $columnName, Expr $columnTca): bool
     {
         if (! $columnTca instanceof Array_) {
             return false;
@@ -140,18 +144,18 @@ CODE_SAMPLE
     }
 
     // todo: this should go into a base class
-    private function resolveVariableDefinition(Node\Expr\Variable $columnsDefinition): ?Node
+    private function resolveVariableDefinition(Variable $columnsDefinition): ?Node
     {
         // we need to find the definition of this variable and refactor that.
         // as a first-order approximation, we look at the previous statement and hope that the argument is defined there
         $previousStatement = $columnsDefinition->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-        if (! $previousStatement->expr instanceof Node\Expr\Assign) {
+        if (! $previousStatement->expr instanceof Assign) {
             // the previous statement is not an assignment
             return null;
         }
         $assignment = $previousStatement->expr;
 
-        if (! $assignment->var instanceof Node\Expr\Variable) {
+        if (! $assignment->var instanceof Variable) {
             // it is not assigning to a variable
             return null;
         }
@@ -172,7 +176,7 @@ CODE_SAMPLE
     // todo: this should go into a base class
     private function refactorAddTcaColumns(Node $node): bool
     {
-        if (! $node instanceof Node\Expr\StaticCall) {
+        if (! $node instanceof StaticCall) {
             return false;
         }
 
@@ -199,7 +203,7 @@ CODE_SAMPLE
         }
 
         $columnsDefinition = $columnsDefinitionArgument->value;
-        if ($columnsDefinition instanceof Node\Expr\Variable) {
+        if ($columnsDefinition instanceof Variable) {
             // the call uses a variable to define the columns.
             // For refactoring we need the node where this variable is defined
             $columnsDefinition = $this->resolveVariableDefinition($columnsDefinition);

--- a/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
+++ b/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
@@ -9,7 +9,9 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Return_;
+use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -32,62 +34,18 @@ final class AddTypeToColumnConfigRector extends AbstractRector
      */
     public function getNodeTypes(): array
     {
-        return [Return_::class];
+        return [Return_::class, Node\Expr\StaticCall::class];
     }
 
     /**
-     * @param Return_ $node
+     * toDo: this should go into a base class
+     *
+     * @param Node|Node\Expr\StaticCall $node
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
-            return null;
-        }
-
-        $columns = $this->extractSubArrayByKey($node->expr, 'columns');
-        if (null === $columns) {
-            return null;
-        }
-
-        $hasAstBeenChanged = false;
-
-        foreach ($columns->items as $columnArrayItem) {
-            if (! $columnArrayItem instanceof ArrayItem) {
-                continue;
-            }
-
-            $columnName = $columnArrayItem->key;
-            if (null === $columnName) {
-                continue;
-            }
-
-            if (! $columnArrayItem->value instanceof Array_) {
-                continue;
-            }
-
-            $config = null;
-            $configItem = $this->extractArrayItemByKey($columnArrayItem->value, 'config');
-
-            if (null !== $configItem) {
-                $config = $configItem->value;
-                if (! $config instanceof  Array_) {
-                    continue;
-                }
-            }
-
-            if (null === $config) {
-                // found a column without a 'config' part. Create an empty 'config' array
-                $config = new Array_();
-                $columnArrayItem->value->items[] = new ArrayItem($config, new String_('config'));
-                $hasAstBeenChanged = true;
-            }
-
-            if (null === $this->extractArrayItemByKey($config, self::TYPE)) {
-                // found a column without a 'type' field in the config. add type => none
-                $config->items[] = new ArrayItem(new String_('none'), new String_(self::TYPE));
-                $hasAstBeenChanged = true;
-            }
-        }
+        $hasAstBeenChanged = $this->refactorFullTca($node);
+        $hasAstBeenChanged = $this->refactorAddTcaColumns($node) ? true : $hasAstBeenChanged;
 
         return $hasAstBeenChanged ? $node : null;
     }
@@ -118,5 +76,157 @@ return [
 ];
 CODE_SAMPLE
         )]);
+    }
+
+    private function refactorColumn(Node\Expr $columnName, Node\Expr $columnTca): bool
+    {
+        if (! $columnTca instanceof Array_) {
+            return false;
+        }
+        $config = null;
+        $configItem = $this->extractArrayItemByKey($columnTca, 'config');
+
+        if (null !== $configItem) {
+            $config = $configItem->value;
+            if (! $config instanceof Array_) {
+                return false;
+            }
+        }
+
+        $hasAstBeenChanged = false;
+        if (null === $config) {
+            // found a column without a 'config' part. Create an empty 'config' array
+            $config = new Array_();
+            $columnTca->items[] = new ArrayItem($config, new String_('config'));
+            $hasAstBeenChanged = true;
+        }
+
+        if (null === $this->extractArrayItemByKey($config, self::TYPE)) {
+            // found a column without a 'type' field in the config. add type => none
+            $config->items[] = new ArrayItem(new String_('none'), new String_(self::TYPE));
+            $hasAstBeenChanged = true;
+        }
+        return $hasAstBeenChanged;
+    }
+
+    // ToDo: this should go into a base class
+    private function refactorFullTca(Node $node): bool
+    {
+        $hasAstBeenChanged = false;
+        if (! $node instanceof Return_ || ! $this->isFullTca($node)) {
+            return false;
+        }
+
+        $columns = $this->extractSubArrayByKey($node->expr, 'columns');
+        if (null === $columns) {
+            return false;
+        }
+
+        foreach ($columns->items as $columnArrayItem) {
+            if (! $columnArrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            $columnName = $columnArrayItem->key;
+            if (null === $columnName) {
+                continue;
+            }
+
+            $columnTca = $columnArrayItem->value;
+
+            $hasAstBeenChanged = $this->refactorColumn($columnName, $columnTca) ? true : $hasAstBeenChanged;
+        }
+        return $hasAstBeenChanged;
+    }
+
+    // todo: this should go into a base class
+    private function resolveColumnsDefinition(Node\Expr $columnsDefinition): ?Node
+    {
+        if ($columnsDefinition instanceof Node\Expr\Variable) {
+            // the call to addTcaColumns uses a variable to define the columns to add.
+            // to effectively refactor this argument, we need to find the definition of this variable and refactor that.
+            // as a first-order approximation, we look at the previous statement and hope that the argument is defined there
+            $previousStatement = $columnsDefinition->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
+            if (! $previousStatement->expr instanceof Node\Expr\Assign) {
+                // the previous statement is not an assignment
+                return null;
+            }
+            $assignment = $previousStatement->expr;
+
+            if (! $assignment->var instanceof Node\Expr\Variable) {
+                // it is not assigning to a variable
+                return null;
+            }
+
+            if ($assignment->var->name !== $columnsDefinition->name) {
+                // it is assigning to a different variable
+                return null;
+            }
+            if (! $assignment->expr instanceof Array_) {
+                // the assigned value is not an array
+                return null;
+            }
+
+            // we found the array definition that is used as the calling argument to addTcaColumns.
+            $columnsDefinition = $assignment->expr;
+        }
+        return $columnsDefinition;
+    }
+
+    // todo: this should go into a base class
+    private function refactorAddTcaColumns(Node $node): bool
+    {
+        if (! $node instanceof Node\Expr\StaticCall) {
+            return false;
+        }
+
+        if (! $this->nodeTypeResolver->isObjectType(
+            $node->class,
+            new ObjectType('TYPO3\CMS\Core\Utility\ExtensionManagementUtility')
+        )) {
+            return false;
+        }
+
+        if (! $this->isName($node->name, 'addTCAcolumns')) {
+            return false;
+        }
+
+        if (2 !== count($node->args)) {
+            return false;
+        }
+
+        [$tableNameArgument, $columnsDefinitionArgument] = $node->args;
+
+        if (! $tableNameArgument->value instanceof String_) {
+            // lets play it safe here - dont refactor calls with the table name not being a string
+            return false;
+        }
+
+        $columnsDefinition = $columnsDefinitionArgument->value;
+        $columnsDefinition = $this->resolveColumnsDefinition($columnsDefinition);
+
+        if (! $columnsDefinition instanceof Array_) {
+            return false;
+        }
+
+        $hasAstBeenChanged = false;
+        foreach ($columnsDefinition->items as $columnArrayItem) {
+            if (! $columnArrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            $columnNameNode = $columnArrayItem->key;
+            $columnConfiguration = $columnArrayItem->value;
+
+            if (null === $columnNameNode) {
+                continue;
+            }
+
+            $hasAstBeenChanged = $this->refactorColumn(
+                $columnNameNode,
+                $columnConfiguration
+            ) ? true : $hasAstBeenChanged;
+        }
+        return $hasAstBeenChanged;
     }
 }

--- a/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
+++ b/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
-use Ssch\TYPO3Rector\Rector\Tca\AbstractColumnwiseTcaRector;
+use Ssch\TYPO3Rector\Rector\Tca\AbstractTcaRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -17,7 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html
  * @see \Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\AddTypeToColumnConfigRectorTest
  */
-final class AddTypeToColumnConfigRector extends AbstractColumnwiseTcaRector
+final class AddTypeToColumnConfigRector extends AbstractTcaRector
 {
     use TcaHelperTrait;
 

--- a/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
+++ b/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
@@ -4,19 +4,12 @@ declare(strict_types=1);
 
 namespace Ssch\TYPO3Rector\Rector\v8\v6;
 
-use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\Stmt\Return_;
-use PHPStan\Type\ObjectType;
-use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Ssch\TYPO3Rector\Helper\TcaHelperTrait;
+use Ssch\TYPO3Rector\Rector\Tca\AbstractColumnwiseTcaRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,14 +17,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html
  * @see \Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\AddTypeToColumnConfigRectorTest
  */
-final class AddTypeToColumnConfigRector extends AbstractRector
+final class AddTypeToColumnConfigRector extends AbstractColumnwiseTcaRector
 {
     use TcaHelperTrait;
-
-    /**
-     * @var string
-     */
-    private const TYPE = 'type';
 
     /**
      * @codeCoverageIgnore
@@ -62,114 +50,17 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<Node>>
-     */
-    public function getNodeTypes(): array
-    {
-        return [Array_::class];
-    }
-
-    /**
-     * toDo: this should go into a base class
+     * Refactors a single TCA column definition like 'column_name' => [ 'label' => 'column label', 'config' => [], ]
      *
-     * @param Array_ $node
-     */
-    public function refactor(Node $node): ?Node
-    {
-        if (!$node instanceof  Array_) {
-            return null;
-        }
-
-        // check for a tca definition of a full table (with columns and ctrl section)
-        $columns = $this->extractSubArrayByKey($node, 'columns');
-        $ctrl = $this->extractArrayItemByKey($node, 'ctrl');
-
-        if (null !== $columns && null !== $ctrl) {
-            // we found a tca definition of a full table. Process it as a whole:
-            return $this->refactorColumnList($columns) ? $node : null;
-        }
-
-        // this is not a full tca definition. Lets check some fuzzier stuff.
-        // it could be a list of columns, as in ExtensionManagementUtility::addTcaColums('table', $node)
-        $hasAstBeenChanged = false;
-        foreach ($node->items as $arrayItem) {
-            if (! $arrayItem instanceof ArrayItem) {
-                // lets play it safe here. a non-associative array is probably not tca.
-                continue;
-            }
-
-            if (! $arrayItem->key instanceof String_) {
-                // the key of a column list in tca is the column name, which needs to be a string.
-                continue;
-            }
-
-            if ($arrayItem->value instanceof Array_) {
-                // we found a single column configuration which is an array
-                // (not a call to stuff like ExtensionManagementUtility::getFileFieldTCAConfig)
-                $labelNode = $this->extractArrayItemByKey($arrayItem->value, 'label');
-                // toDo: not everything that has a label is tca. check for more stuff like config or exclude here!
-                //  but in this special case we can't test for 'type' as this rector should add that.
-                if (null !== $labelNode) {
-                    $hasAstBeenChanged = $this->refactorColumn($arrayItem->key, $arrayItem->value) ? true : $hasAstBeenChanged;
-                }
-            }
-        }
-
-        return $hasAstBeenChanged ? $node : null;
-    }
-
-    /**
-     * refactors an TCA array such as
-     * [
-     *      'column_1' => [
-     *          'label' => 'column 1', ...
-     *          'config' => ...
-     *      ],
-     *      'column_2' => [
-     *          'label' => 'column 2', ...
-     *          'config' => ...
-     *      ]
-     * ]
-     *
-     * @param Array_ $columns a list of TCA definitions for columns
-     * @return bool whether the AST has been changed by the operation
-     */
-    private function refactorColumnList(Array_ $columns): bool
-    {
-        $hasAstBeenChanged = false;
-        foreach ($columns->items as $columnArrayItem) {
-            if (! $columnArrayItem instanceof ArrayItem) {
-                continue;
-            }
-
-            $columnName = $columnArrayItem->key;
-            if (null === $columnName) {
-                continue;
-            }
-
-            $columnTca = $columnArrayItem->value;
-
-            $hasAstBeenChanged = $this->refactorColumn($columnName, $columnTca) ? true : $hasAstBeenChanged;
-        }
-        return $hasAstBeenChanged;
-    }
-
-    /**
-     * Refactors a single TCA column definition like
-     *
-     * 'column_name' => [
-     *      'label' => 'column label',
-     *      'config' => [],
-     * ]
+     * remark: checking if the passed nodes really are a TCA snippet must be checked by the caller.
      *
      * @param Expr $columnName the key in above example (typically String_('column_name'))
      * @param Expr $columnTca the value in above example (typically an associative Array with stuff like 'label', 'config', 'exclude', ...)
-     * @return bool
      */
-    private function refactorColumn(Expr $columnName, Expr $columnTca): bool
+    protected function refactorColumn(Expr $columnName, Expr $columnTca): void
     {
         if (! $columnTca instanceof Array_) {
-            return false;
+            return;
         }
         $config = null;
         $configItem = $this->extractArrayItemByKey($columnTca, 'config');
@@ -177,23 +68,33 @@ CODE_SAMPLE
         if (null !== $configItem) {
             $config = $configItem->value;
             if (! $config instanceof Array_) {
-                return false;
+                return;
             }
         }
 
-        $hasAstBeenChanged = false;
         if (null === $config) {
             // found a column without a 'config' part. Create an empty 'config' array
             $config = new Array_();
             $columnTca->items[] = new ArrayItem($config, new String_('config'));
-            $hasAstBeenChanged = true;
+            $this->hasAstBeenChanged = true;
         }
 
         if (null === $this->extractArrayItemByKey($config, self::TYPE)) {
             // found a column without a 'type' field in the config. add type => none
             $config->items[] = new ArrayItem(new String_('none'), new String_(self::TYPE));
-            $hasAstBeenChanged = true;
+            $this->hasAstBeenChanged = true;
         }
-        return $hasAstBeenChanged;
+    }
+
+    /**
+     * We need to weaken the typical constraint regarding column-config detection here, as the configs we are targeting
+     * won't contain a 'type' field.
+     *
+     * @inheritdoc
+     */
+    protected function isSingleTcaColumn(ArrayItem $arrayItem): bool
+    {
+        $labelNode = $this->extractArrayItemByKey($arrayItem->value, 'label');
+        return null !== $labelNode;
     }
 }

--- a/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
+++ b/src/Rector/v8/v6/AddTypeToColumnConfigRector.php
@@ -116,7 +116,6 @@ CODE_SAMPLE
     // ToDo: this should go into a base class
     private function refactorFullTca(Node $node): bool
     {
-        $hasAstBeenChanged = false;
         if (! $node instanceof Return_ || ! $this->isFullTca($node)) {
             return false;
         }
@@ -126,21 +125,7 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($columns->items as $columnArrayItem) {
-            if (! $columnArrayItem instanceof ArrayItem) {
-                continue;
-            }
-
-            $columnName = $columnArrayItem->key;
-            if (null === $columnName) {
-                continue;
-            }
-
-            $columnTca = $columnArrayItem->value;
-
-            $hasAstBeenChanged = $this->refactorColumn($columnName, $columnTca) ? true : $hasAstBeenChanged;
-        }
-        return $hasAstBeenChanged;
+        return $this->refactorTcaColumns($columns);
     }
 
     // todo: this should go into a base class
@@ -213,23 +198,26 @@ CODE_SAMPLE
             return false;
         }
 
+        return $this->refactorTcaColumns($columnsDefinition);
+    }
+
+    // todo: this should go into a baseclass
+    private function refactorTcaColumns(Array_ $columns): bool
+    {
         $hasAstBeenChanged = false;
-        foreach ($columnsDefinition->items as $columnArrayItem) {
+        foreach ($columns->items as $columnArrayItem) {
             if (! $columnArrayItem instanceof ArrayItem) {
                 continue;
             }
 
-            $columnNameNode = $columnArrayItem->key;
-            $columnConfiguration = $columnArrayItem->value;
-
-            if (null === $columnNameNode) {
+            $columnName = $columnArrayItem->key;
+            if (null === $columnName) {
                 continue;
             }
 
-            $hasAstBeenChanged = $this->refactorColumn(
-                $columnNameNode,
-                $columnConfiguration
-            ) ? true : $hasAstBeenChanged;
+            $columnTca = $columnArrayItem->value;
+
+            $hasAstBeenChanged = $this->refactorColumn($columnName, $columnTca) ? true : $hasAstBeenChanged;
         }
         return $hasAstBeenChanged;
     }

--- a/src/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector.php
+++ b/src/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector.php
@@ -41,7 +41,7 @@ final class MigrateLastPiecesOfDefaultExtrasRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/MigrateOptionsOfTypeGroupRector.php
+++ b/src/Rector/v8/v6/MigrateOptionsOfTypeGroupRector.php
@@ -51,7 +51,7 @@ final class MigrateOptionsOfTypeGroupRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/MigrateSelectShowIconTableRector.php
+++ b/src/Rector/v8/v6/MigrateSelectShowIconTableRector.php
@@ -40,7 +40,7 @@ final class MigrateSelectShowIconTableRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/MoveRequestUpdateOptionFromControlToColumnsRector.php
+++ b/src/Rector/v8/v6/MoveRequestUpdateOptionFromControlToColumnsRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/MoveTypeGroupSuggestWizardToSuggestOptionsRector.php
+++ b/src/Rector/v8/v6/MoveTypeGroupSuggestWizardToSuggestOptionsRector.php
@@ -102,7 +102,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/RefactorTCARector.php
+++ b/src/Rector/v8/v6/RefactorTCARector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/RemoveL10nModeNoCopyRector.php
+++ b/src/Rector/v8/v6/RemoveL10nModeNoCopyRector.php
@@ -46,7 +46,7 @@ final class RemoveL10nModeNoCopyRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v6/RichtextFromDefaultExtrasToEnableRichtextRector.php
+++ b/src/Rector/v8/v6/RichtextFromDefaultExtrasToEnableRichtextRector.php
@@ -78,7 +78,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $this->hasAstBeenChanged = false;
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v7/MoveForeignTypesToOverrideChildTcaRector.php
+++ b/src/Rector/v8/v7/MoveForeignTypesToOverrideChildTcaRector.php
@@ -110,7 +110,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v7/RemoveConfigMaxFromInputDateTimeFieldsRector.php
+++ b/src/Rector/v8/v7/RemoveConfigMaxFromInputDateTimeFieldsRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v8/v7/RemoveLocalizationModeKeepIfNeededRector.php
+++ b/src/Rector/v8/v7/RemoveLocalizationModeKeepIfNeededRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v9/v0/RemoveOptionLocalizeChildrenAtParentLocalizationRector.php
+++ b/src/Rector/v9/v0/RemoveOptionLocalizeChildrenAtParentLocalizationRector.php
@@ -74,7 +74,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/src/Rector/v9/v5/RefactorTypeInternalTypeFileAndFileReferenceToFalRector.php
+++ b/src/Rector/v9/v5/RefactorTypeInternalTypeFileAndFileReferenceToFalRector.php
@@ -51,7 +51,7 @@ final class RefactorTypeInternalTypeFileAndFileReferenceToFalRector extends Abst
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isTca($node)) {
+        if (! $this->isFullTca($node)) {
             return null;
         }
 

--- a/stubs/TYPO3/CMS/Core/Utility/ExtensionManagementUtility.php
+++ b/stubs/TYPO3/CMS/Core/Utility/ExtensionManagementUtility.php
@@ -63,4 +63,8 @@ class ExtensionManagementUtility
     {
         return [];
     }
+
+    public static function addTCAcolumns(string $string, array $columns) {
+
+    }
 }

--- a/tests/Rector/v7/v6/AddRenderTypeToSelectFieldRector/Fixture/add_render_type.php.inc
+++ b/tests/Rector/v7/v6/AddRenderTypeToSelectFieldRector/Fixture/add_render_type.php.inc
@@ -42,15 +42,15 @@ return [
         'sys_language_uid' => [
             'config' => [
                 'type' => 'select',
-                'maxitems' => 1,
                 'renderType' => 'selectSingle',
+                'maxitems' => 1,
             ],
         ],
         'positive' => [
             'config' => [
                 'type' => 'select',
-                'maxitems' => 5,
                 'renderType' => 'selectMultipleSideBySide',
+                'maxitems' => 5,
             ],
         ],
         'foo' => [
@@ -62,8 +62,8 @@ return [
         'bar' => [
             'config' => [
                 'type' => 'select',
-                'renderMode' => 'tree',
                 'renderType' => 'selectTree',
+                'renderMode' => 'tree',
             ],
         ],
     ],

--- a/tests/Rector/v7/v6/AddRenderTypeToSelectFieldRector/Fixture/add_render_type_in_add_tca_columns.php.inc
+++ b/tests/Rector/v7/v6/AddRenderTypeToSelectFieldRector/Fixture/add_render_type_in_add_tca_columns.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+$tmp_showings_columns = [
+    'showing' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_showings_domain_model_spaceunit.showing',
+        'config' => [
+            'type' => 'select',
+            'foreign_table' => 'tx_showings_domain_model_showing',
+            'items' => [
+                ['', '']
+            ],
+            'readOnly' => 1,
+        ],
+    ],
+];
+ExtensionManagementUtility::addTCAcolumns('tx_offers_domain_model_offer',
+    $tmp_showings_columns);
+
+?>
+-----
+<?php
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+$tmp_showings_columns = [
+    'showing' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_showings_domain_model_spaceunit.showing',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectSingle',
+            'foreign_table' => 'tx_showings_domain_model_showing',
+            'items' => [
+                ['', '']
+            ],
+            'readOnly' => 1,
+        ],
+    ],
+];
+ExtensionManagementUtility::addTCAcolumns('tx_offers_domain_model_offer',
+    $tmp_showings_columns);
+
+?>

--- a/tests/Rector/v8/v6/AddTypeToColumnConfigRector/Fixture/tca_override_add_column.php.inc
+++ b/tests/Rector/v8/v6/AddTypeToColumnConfigRector/Fixture/tca_override_add_column.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+$new_columns = [
+    'bar' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.bar',
+        'config' => [
+        ],
+    ],
+    'baz' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+    ],
+    'correct' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+        'config' => [
+            'type' => 'text',
+        ]
+    ],
+];
+
+ExtensionManagementUtility::addTCAcolumns('tx_example_domain_model_foo', $new_columns);
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+$new_columns = [
+    'bar' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.bar',
+        'config' => ['type' => 'none'],
+    ],
+    'baz' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+        'config' => ['type' => 'none'],
+    ],
+    'correct' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+        'config' => [
+            'type' => 'text',
+        ]
+    ],
+];
+
+ExtensionManagementUtility::addTCAcolumns('tx_example_domain_model_foo', $new_columns);
+
+?>

--- a/tests/Rector/v8/v6/AddTypeToColumnConfigRector/Fixture/tca_override_add_column.php.inc
+++ b/tests/Rector/v8/v6/AddTypeToColumnConfigRector/Fixture/tca_override_add_column.php.inc
@@ -4,6 +4,26 @@ namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixtur
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
+ExtensionManagementUtility::addTCAcolumns('tx_example_domain_model_foo', [
+    'bar' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.bar',
+        'config' => [
+        ],
+    ],
+    'baz' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+    ],
+    'correct' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+        'config' => [
+            'type' => 'text',
+        ]
+    ],
+]);
+
 $new_columns = [
     'bar' => [
         'exclude' => 1,
@@ -33,6 +53,26 @@ ExtensionManagementUtility::addTCAcolumns('tx_example_domain_model_foo', $new_co
 namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+ExtensionManagementUtility::addTCAcolumns('tx_example_domain_model_foo', [
+    'bar' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.bar',
+        'config' => ['type' => 'none'],
+    ],
+    'baz' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+        'config' => ['type' => 'none'],
+    ],
+    'correct' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:offers/Resources/Private/Language/locallang_db.xlf:tx_example_domain_model_foo.baz',
+        'config' => [
+            'type' => 'text',
+        ]
+    ],
+]);
 
 $new_columns = [
     'bar' => [

--- a/utils/phpstan/src/Rules/AddChangelogDocBlockForRectorClass.php
+++ b/utils/phpstan/src/Rules/AddChangelogDocBlockForRectorClass.php
@@ -14,6 +14,7 @@ use PHPStan\Type\FileTypeMapper;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Ssch\TYPO3Rector\Rector\General\ConvertTypo3ConfVarsRector;
 use Ssch\TYPO3Rector\Rector\Migrations\RenameClassMapAliasRector;
+use Ssch\TYPO3Rector\Rector\Tca\AbstractTcaRector;
 use Ssch\TYPO3Rector\Rules\Rector\Misc\AddCodeCoverageIgnoreToMethodRectorDefinitionRector;
 
 /**
@@ -33,6 +34,7 @@ final class AddChangelogDocBlockForRectorClass implements Rule
         RenameClassMapAliasRector::class,
         AddCodeCoverageIgnoreToMethodRectorDefinitionRector::class,
         ConvertTypo3ConfVarsRector::class,
+        AbstractTcaRector::class,
     ];
 
     /**


### PR DESCRIPTION
This is a first draft of my thoughts about column-wise tca refactoring.
I chose an easy one to show how the code will look like.

Handling stuff like 'move things into/out of the types section' or other cross-dependencies between other parts of tca and the 'columns' part is still WIP, but please have a look.

I tend to extract some stuff into a base-class such as `AbstractColumnwiseTcaRector`. Or would you prefer to have that in the trait instead @sabbelasichon ?

partially fixes #2188 