### PR TITLE
Move special configuration to columns overrides

### DIFF
--- a/config/v8/tca-87.php
+++ b/config/v8/tca-87.php
@@ -13,6 +13,7 @@ use Ssch\TYPO3Rector\Rector\v8\v6\AddTypeToColumnConfigRector;
 use Ssch\TYPO3Rector\Rector\v8\v6\MigrateLastPiecesOfDefaultExtrasRector;
 use Ssch\TYPO3Rector\Rector\v8\v6\MigrateOptionsOfTypeGroupRector;
 use Ssch\TYPO3Rector\Rector\v8\v6\MigrateSelectShowIconTableRector;
+use Ssch\TYPO3Rector\Rector\v8\v6\MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector;
 use Ssch\TYPO3Rector\Rector\v8\v6\MoveRequestUpdateOptionFromControlToColumnsRector;
 use Ssch\TYPO3Rector\Rector\v8\v6\MoveTypeGroupSuggestWizardToSuggestOptionsRector;
 use Ssch\TYPO3Rector\Rector\v8\v6\RefactorTCARector;
@@ -67,4 +68,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(MoveForeignTypesToOverrideChildTcaRector::class);
     $services->set(MigrateLastPiecesOfDefaultExtrasRector::class);
     $services->set(MoveTypeGroupSuggestWizardToSuggestOptionsRector::class);
+    $services->set(MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector::class);
 };

--- a/src/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector.php
+++ b/src/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector.php
@@ -242,26 +242,18 @@ CODE_SAMPLE
             if ([] !== $additionalConfigItems) {
                 $this->hasAstBeenChanged = true;
 
-                foreach ($columnItem->value->items as $configValue) {
-                    if (null === $configValue) {
-                        continue;
-                    }
+                $config = $this->extractArrayItemByKey($columnItem->value, 'config');
+                if (null === $config) {
+                    $config = new ArrayItem(new Array_(), new String_('config'));
+                    $columnItem->value->items[] = $config;
+                }
 
-                    if (null === $configValue->key) {
-                        continue;
-                    }
+                if (! $config->value instanceof Array_) {
+                    continue;
+                }
 
-                    if (! $this->valueResolver->isValue($configValue->key, 'config')) {
-                        continue;
-                    }
-
-                    if (! $configValue->value instanceof Array_) {
-                        continue;
-                    }
-
-                    foreach ($additionalConfigItems as $additionalConfigItem) {
-                        $configValue->value->items[] = $additionalConfigItem;
-                    }
+                foreach ($additionalConfigItems as $additionalConfigItem) {
+                    $config->value->items[] = $additionalConfigItem;
                 }
             }
         }

--- a/src/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector.php
+++ b/src/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Rector\v8\v6;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use Ssch\TYPO3Rector\Helper\ArrayUtility;
+use Ssch\TYPO3Rector\Rector\Tca\AbstractTcaRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html
+ */
+final class MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector extends AbstractTcaRector
+{
+    /**
+     * @var array<string, string>
+     */
+    private $defaultExtrasFromColumns = [];
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Move special configuration to columns overrides', [new CodeSample(
+            <<<'CODE_SAMPLE'
+return [
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with;;nowrap,thirdField',
+        ],
+    ],
+];
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+return [
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField',
+            'columnsOverrides' => [
+                'anotherField' => [
+                    'config' => [
+                        'wrap' => 'off',
+                    ]
+                ],
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE
+        )]);
+    }
+
+    protected function resetInnerState(): void
+    {
+        $this->defaultExtrasFromColumns = [];
+    }
+
+    protected function refactorColumn(Expr $columnName, Expr $columnTca): void
+    {
+        if (! $columnTca instanceof Array_) {
+            return;
+        }
+
+        $defaultExtras = $this->extractArrayValueByKey($columnTca, 'defaultExtras');
+        if (null === $defaultExtras) {
+            return;
+        }
+
+        $this->defaultExtrasFromColumns[$this->valueResolver->getValue($columnName)] = $this->valueResolver->getValue(
+            $defaultExtras
+        );
+    }
+
+    protected function refactorTypes(Array_ $types): void
+    {
+        foreach ($types->items as $typeArrayItem) {
+            if (! $typeArrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            if (! $typeArrayItem->value instanceof Array_) {
+                continue;
+            }
+
+            $typeConfiguration = $typeArrayItem->value;
+            $showitemNode = $this->extractArrayValueByKey($typeConfiguration, 'showitem');
+
+            if (! $showitemNode instanceof String_) {
+                continue;
+            }
+
+            $showitem = $this->valueResolver->getValue($showitemNode);
+            if (! is_string($showitem)) {
+                continue;
+            }
+
+            if (false === strpos($showitem, ';')) {
+                // Continue directly if no semicolon is found
+                continue;
+            }
+            $itemList = explode(',', $showitem);
+            $newFieldStrings = [];
+            foreach ($itemList as $fieldString) {
+                $fieldString = rtrim($fieldString, ';');
+                // Unpack the field definition, migrate and remove as much as possible
+                // Keep empty parameters in trimExplode here (third parameter FALSE), so position is not changed
+                $fieldArray = ArrayUtility::trimExplode(';', $fieldString);
+                $fieldArray = [
+                    'fieldName' => isset($fieldArray[0]) ? $fieldArray[0] : '',
+                    'fieldLabel' => isset($fieldArray[1]) ? $fieldArray[1] : null,
+                    'paletteName' => isset($fieldArray[2]) ? $fieldArray[2] : null,
+                    'fieldExtra' => isset($fieldArray[3]) ? $fieldArray[3] : null,
+                ];
+                $fieldName = $fieldArray['fieldName'];
+                if (null !== $fieldArray['fieldExtra']) {
+                    // Move fieldExtra "specConf" to columnsOverrides "defaultExtras"
+                    // Merge with given defaultExtras from columns.
+                    // They will be the first part of the string, so if "specConf" from types changes the same settings,
+                    // those will override settings from defaultExtras of columns
+                    $newDefaultExtras = [];
+                    if (isset($this->defaultExtrasFromColumns[$fieldName])) {
+                        $newDefaultExtras[] = $this->defaultExtrasFromColumns[$fieldName];
+                    }
+
+                    $newDefaultExtras[] = $fieldArray['fieldExtra'];
+                    $newDefaultExtras = implode(':', $newDefaultExtras);
+                    if ('' !== $newDefaultExtras) {
+                        $columnsOverrides = $this->extractSubArrayByKey($typeConfiguration, 'columnsOverrides');
+                        if (null === $columnsOverrides) {
+                            $columnsOverrides = new Array_([]);
+                            $typeConfiguration->items[] = new ArrayItem($columnsOverrides, new String_(
+                                'columnsOverrides'
+                            ));
+                        }
+
+                        $columnOverride = $this->extractSubArrayByKey($columnsOverrides, $fieldName);
+                        if (null === $columnOverride) {
+                            $columnOverride = new Array_([]);
+                            $columnsOverrides->items[] = new ArrayItem($columnOverride, new String_($fieldName));
+                        }
+                        $columnOverride->items[] = new ArrayItem(new String_($newDefaultExtras), new String_(
+                            'defaultExtras'
+                        ));
+                        $this->hasAstBeenChanged = true;
+                    }
+                }
+
+                unset($fieldArray['fieldExtra']);
+                if (3 === count($fieldArray) && empty($fieldArray['paletteName'])) {
+                    unset($fieldArray['paletteName']);
+                }
+                if (2 === count($fieldArray) && empty($fieldArray['fieldLabel'])) {
+                    unset($fieldArray['fieldLabel']);
+                }
+                if (1 === count($fieldArray) && empty($fieldArray['fieldName'])) {
+                    // The field may vanish if nothing is left
+                    unset($fieldArray['fieldName']);
+                }
+                $newFieldString = implode(';', $fieldArray);
+                if (! empty($newFieldString)) {
+                    $newFieldStrings[] = $newFieldString;
+                }
+            }
+            $showitemNode->value = implode(',', $newFieldStrings);
+        }
+    }
+}

--- a/src/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector.php
+++ b/src/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector.php
@@ -15,9 +15,30 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @changelog https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html
+ * @see Ssch\TYPO3Rector\Tests\Rector\v8\v6\MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest\MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest
  */
 final class MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector extends AbstractTcaRector
 {
+    /**
+     * @var string
+     */
+    private const FIELD_NAME = 'fieldName';
+
+    /**
+     * @var string
+     */
+    private const FIELD_LABEL = 'fieldLabel';
+
+    /**
+     * @var string
+     */
+    private const PALETTE_NAME = 'paletteName';
+
+    /**
+     * @var string
+     */
+    private const FIELD_EXTRA = 'fieldExtra';
+
     /**
      * @var array<string, string>
      */
@@ -46,9 +67,7 @@ return [
             'showitem' => 'aField,anotherField;with,thirdField',
             'columnsOverrides' => [
                 'anotherField' => [
-                    'config' => [
-                        'wrap' => 'off',
-                    ]
+                    'defaultExtras' => 'nowrap',
                 ],
             ],
         ],
@@ -114,13 +133,13 @@ CODE_SAMPLE
                 // Keep empty parameters in trimExplode here (third parameter FALSE), so position is not changed
                 $fieldArray = ArrayUtility::trimExplode(';', $fieldString);
                 $fieldArray = [
-                    'fieldName' => isset($fieldArray[0]) ? $fieldArray[0] : '',
-                    'fieldLabel' => isset($fieldArray[1]) ? $fieldArray[1] : null,
-                    'paletteName' => isset($fieldArray[2]) ? $fieldArray[2] : null,
-                    'fieldExtra' => isset($fieldArray[3]) ? $fieldArray[3] : null,
+                    self::FIELD_NAME => isset($fieldArray[0]) ? $fieldArray[0] : '',
+                    self::FIELD_LABEL => isset($fieldArray[1]) ? $fieldArray[1] : null,
+                    self::PALETTE_NAME => isset($fieldArray[2]) ? $fieldArray[2] : null,
+                    self::FIELD_EXTRA => isset($fieldArray[3]) ? $fieldArray[3] : null,
                 ];
-                $fieldName = $fieldArray['fieldName'];
-                if (null !== $fieldArray['fieldExtra']) {
+                $fieldName = $fieldArray[self::FIELD_NAME];
+                if (null !== $fieldArray[self::FIELD_EXTRA]) {
                     // Move fieldExtra "specConf" to columnsOverrides "defaultExtras"
                     // Merge with given defaultExtras from columns.
                     // They will be the first part of the string, so if "specConf" from types changes the same settings,
@@ -130,7 +149,7 @@ CODE_SAMPLE
                         $newDefaultExtras[] = $this->defaultExtrasFromColumns[$fieldName];
                     }
 
-                    $newDefaultExtras[] = $fieldArray['fieldExtra'];
+                    $newDefaultExtras[] = $fieldArray[self::FIELD_EXTRA];
                     $newDefaultExtras = implode(':', $newDefaultExtras);
                     if ('' !== $newDefaultExtras) {
                         $columnsOverrides = $this->extractSubArrayByKey($typeConfiguration, 'columnsOverrides');
@@ -153,19 +172,19 @@ CODE_SAMPLE
                     }
                 }
 
-                unset($fieldArray['fieldExtra']);
-                if (3 === count($fieldArray) && empty($fieldArray['paletteName'])) {
-                    unset($fieldArray['paletteName']);
+                unset($fieldArray[self::FIELD_EXTRA]);
+                if (3 === count($fieldArray) && '' === ($fieldArray[self::PALETTE_NAME] ?? '')) {
+                    unset($fieldArray[self::PALETTE_NAME]);
                 }
-                if (2 === count($fieldArray) && empty($fieldArray['fieldLabel'])) {
-                    unset($fieldArray['fieldLabel']);
+                if (2 === count($fieldArray) && '' === ($fieldArray[self::FIELD_LABEL] ?? '')) {
+                    unset($fieldArray[self::FIELD_LABEL]);
                 }
-                if (1 === count($fieldArray) && empty($fieldArray['fieldName'])) {
+                if (1 === count($fieldArray) && '' === $fieldArray[self::FIELD_NAME]) {
                     // The field may vanish if nothing is left
-                    unset($fieldArray['fieldName']);
+                    unset($fieldArray[self::FIELD_NAME]);
                 }
                 $newFieldString = implode(';', $fieldArray);
-                if (! empty($newFieldString)) {
+                if ('' !== $newFieldString) {
                     $newFieldStrings[] = $newFieldString;
                 }
             }

--- a/tests/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector/Fixture/migrate_moves_nowrap_and_enable-tab.php.inc
+++ b/tests/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector/Fixture/migrate_moves_nowrap_and_enable-tab.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'anotherField' => [
+            'defaultExtras' => 'nowrap',
+        ],
+    ],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField', 'columnsOverrides' => ['anotherField' => ['defaultExtras' => 'nowrap:enable-tab']],
+        ],
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'anotherField' => [
+            'config' => ['wrap' => 'off'],
+        ],
+    ],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField', 'columnsOverrides' => ['anotherField' => ['config' => ['wrap' => 'off', 'enableTabulator' => true]]],
+        ],
+    ],
+];
+
+?>

--- a/tests/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector/Fixture/migrate_wrap_to_columns_override_without_existing_config.php.inc
+++ b/tests/Rector/v8/v6/MigrateLastPiecesOfDefaultExtrasRector/Fixture/migrate_wrap_to_columns_override_without_existing_config.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField', 'columnsOverrides' => ['anotherField' => ['defaultExtras' => 'nowrap']],
+        ],
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField', 'columnsOverrides' => ['anotherField' => ['config' => ['wrap' => 'off']]],
+        ],
+    ],
+];
+
+?>

--- a/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/Fixture/migrate_drops_style_pointer_from_show_item.php.inc
+++ b/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/Fixture/migrate_drops_style_pointer_from_show_item.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with;;;style-pointer,thirdField',
+        ],
+        1 => [
+            'showitem' => 'aField,;;;;only-a-style-pointer,anotherField',
+        ],
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField',
+        ],
+        1 => [
+            'showitem' => 'aField,anotherField',
+        ],
+    ],
+];
+
+?>

--- a/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/Fixture/migrate_moves_special_configuration_to_columns_overrides_default_extras.php.inc
+++ b/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/Fixture/migrate_moves_special_configuration_to_columns_overrides_default_extras.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with;;nowrap,thirdField',
+        ],
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField', 'columnsOverrides' => ['anotherField' => ['defaultExtras' => 'nowrap']],
+        ],
+    ],
+];
+
+?>

--- a/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/Fixture/migrate_moves_special_configuration_to_columns_overrides_default_extras_and_merges_existing_default_extras.php.inc
+++ b/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/Fixture/migrate_moves_special_configuration_to_columns_overrides_default_extras_and_merges_existing_default_extras.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'anotherField' => [
+            'defaultExtras' => 'nowrap',
+        ],
+    ],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with;;enable-tab,thirdField',
+        ],
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\AddTypeToColumnConfigRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'anotherField' => [
+            'defaultExtras' => 'nowrap',
+        ],
+    ],
+    'types' => [
+        0 => [
+            'showitem' => 'aField,anotherField;with,thirdField', 'columnsOverrides' => ['anotherField' => ['defaultExtras' => 'nowrap:enable-tab']],
+        ],
+    ],
+];
+
+?>

--- a/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest.php
+++ b/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v8\v6\MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/config/configured_rule.php
+++ b/tests/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRectorTest/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Ssch\TYPO3Rector\Rector\v8\v6\MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+    $services->set(MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector::class);
+};


### PR DESCRIPTION
fixes #1988 

The tests for the core migration take into account that another migration is run after the one handled here.
To separate responsibilities and keep the code close to the core migration, i chose to adapt the fixtures and add some test-cases to the second rector that ensures that we finally reach the desired state after running both of them.