### PR TITLE
[BUGFIX] Skip refactoring for constants

### DIFF
--- a/src/Rector/v9/v4/ConstantsToEnvironmentApiCallRector.php
+++ b/src/Rector/v9/v4/ConstantsToEnvironmentApiCallRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector\Rector\v9\v4;
 
 use PhpParser\Node;
+use PhpParser\Node\Const_;
 use PhpParser\Node\Expr\BinaryOp\BitwiseAnd;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
@@ -84,6 +85,12 @@ final class ConstantsToEnvironmentApiCallRector extends AbstractRector
         $property = $this->betterNodeFinder->findParentType($node, Property::class);
 
         if (null !== $property) {
+            return null;
+        }
+
+        $constant = $this->betterNodeFinder->findParentType($node, Const_::class);
+
+        if (null !== $constant) {
             return null;
         }
 

--- a/tests/Rector/v9/v4/ConstantsToEnvironmentApiCallRector/Fixture/environment_constants.php.inc
+++ b/tests/Rector/v9/v4/ConstantsToEnvironmentApiCallRector/Fixture/environment_constants.php.inc
@@ -4,6 +4,8 @@ final class ClassWithALotOfEnvironmentVariables
 {
     private $foo = PATH_site . '/bar/';
 
+    protected const LOGFILE = PATH_site . 'secured/logs/confirmation.csv';
+
     public function method(): void
     {
         PATH_thisScript . 'something';
@@ -24,6 +26,8 @@ use TYPO3\CMS\Core\Core\Environment;
 final class ClassWithALotOfEnvironmentVariables
 {
     private $foo = PATH_site . '/bar/';
+
+    protected const LOGFILE = PATH_site . 'secured/logs/confirmation.csv';
 
     public function method(): void
     {


### PR DESCRIPTION
- Method calls in constants is not allowed. So skip it

Resolves: #2451