### PR TITLE
Make extensive use of PHP8/7.4

### DIFF
--- a/src/FileProcessor/Composer/Rector/ExtensionComposerRector.php
+++ b/src/FileProcessor/Composer/Rector/ExtensionComposerRector.php
@@ -147,7 +147,7 @@ CODE_SAMPLE
             return;
         }
 
-        if (false === strpos($name, '_')) {
+        if (!str_contains($name, '_')) {
             return;
         }
 

--- a/src/FileProcessor/TypoScript/Conditions/GlobalStringConditionMatcher.php
+++ b/src/FileProcessor/TypoScript/Conditions/GlobalStringConditionMatcher.php
@@ -45,7 +45,8 @@ final class GlobalStringConditionMatcher extends AbstractGlobalConditionMatcher
                 'IENV' => $this->createIndependentCondition($property, $operator, $value),
                 'TSFE' => $this->refactorTsfe($property, $operator, $value),
                 'GP' => $this->refactorGetPost($property, $operator, $value),
-                'LIT' => sprintf('"%s" %s "%s"', $value, self::OPERATOR_MAPPING[$operator], $property)
+                'LIT' => sprintf('"%s" %s "%s"', $value, self::OPERATOR_MAPPING[$operator], $property),
+                default => '',
             };
         }
 

--- a/src/FileProcessor/TypoScript/Conditions/GlobalStringConditionMatcher.php
+++ b/src/FileProcessor/TypoScript/Conditions/GlobalStringConditionMatcher.php
@@ -40,17 +40,13 @@ final class GlobalStringConditionMatcher extends AbstractGlobalConditionMatcher
             $operator = trim($matches['operator']);
             $value = trim($matches['value']);
 
-            if ('ENV' === $type) {
-                $newConditions[] = $this->createEnvCondition($property, $operator, $value);
-            } elseif ('IENV' === $type) {
-                $newConditions[] = $this->createIndependentCondition($property, $operator, $value);
-            } elseif ('TSFE' === $type) {
-                $newConditions[] = $this->refactorTsfe($property, $operator, $value);
-            } elseif ('GP' === $type) {
-                $newConditions[] = $this->refactorGetPost($property, $operator, $value);
-            } elseif ('LIT' === $type) {
-                $newConditions[] = sprintf('"%s" %s "%s"', $value, self::OPERATOR_MAPPING[$operator], $property);
-            }
+            $newConditions[] = match ($type) {
+                'ENV' => $this->createEnvCondition($property, $operator, $value),
+                'IENV' => $this->createIndependentCondition($property, $operator, $value),
+                'TSFE' => $this->refactorTsfe($property, $operator, $value),
+                'GP' => $this->refactorGetPost($property, $operator, $value),
+                'LIT' => sprintf('"%s" %s "%s"', $value, self::OPERATOR_MAPPING[$operator], $property)
+            };
         }
 
         return implode(' || ', $newConditions);

--- a/src/FileProcessor/TypoScript/Conditions/GlobalVarConditionMatcher.php
+++ b/src/FileProcessor/TypoScript/Conditions/GlobalVarConditionMatcher.php
@@ -60,6 +60,7 @@ final class GlobalVarConditionMatcher extends AbstractGlobalConditionMatcher
                 'ENV' => $this->createEnvCondition($property, $operator, $value),
                 'IENV' => $this->createIndependentCondition($property, $operator, $value),
                 'BE_USER' => $this->createBackendUserCondition($property, $operator, $value),
+                default => '',
             };
         }
 

--- a/src/FileProcessor/TypoScript/Conditions/GlobalVarConditionMatcher.php
+++ b/src/FileProcessor/TypoScript/Conditions/GlobalVarConditionMatcher.php
@@ -53,19 +53,14 @@ final class GlobalVarConditionMatcher extends AbstractGlobalConditionMatcher
                 $conditions[$key] = [];
             }
 
-            if ('TSFE' === $type) {
-                $conditions[$key][] = $this->refactorTsfe($property, $operator, $value);
-            } elseif ('GP' === $type) {
-                $conditions[$key][] = $this->refactorGetPost($property, $operator, $value);
-            } elseif ('LIT' === $type) {
-                $conditions[$key][] = sprintf('"%s" %s "%s"', $value, self::OPERATOR_MAPPING[$operator], $property);
-            } elseif ('ENV' === $type) {
-                $conditions[$key][] = $this->createEnvCondition($property, $operator, $value);
-            } elseif ('IENV' === $type) {
-                $conditions[$key][] = $this->createIndependentCondition($property, $operator, $value);
-            } elseif ('BE_USER' === $type) {
-                $conditions[$key][] = $this->createBackendUserCondition($property, $operator, $value);
-            }
+            $conditions[$key][] = match ($type) {
+                'TSFE' => $this->refactorTsfe($property, $operator, $value),
+                'GP' => $this->refactorGetPost($property, $operator, $value),
+                'LIT' => sprintf('"%s" %s "%s"', $value, self::OPERATOR_MAPPING[$operator], $property),
+                'ENV' => $this->createEnvCondition($property, $operator, $value),
+                'IENV' => $this->createIndependentCondition($property, $operator, $value),
+                'BE_USER' => $this->createBackendUserCondition($property, $operator, $value),
+            };
         }
 
         $keys = array_keys($conditions);

--- a/src/FileProcessor/TypoScript/Rector/OldConditionToExpressionLanguageTypoScriptRector.php
+++ b/src/FileProcessor/TypoScript/Rector/OldConditionToExpressionLanguageTypoScriptRector.php
@@ -41,28 +41,24 @@ final class OldConditionToExpressionLanguageTypoScriptRector extends AbstractTyp
         $conditions = array_filter($conditions);
         $operators = array_filter($operators);
 
-        $operators = array_map(function (array $match) {
-            return $match[1];
-        }, $operators);
-
-        $conditions = array_map(function (array $match) {
-            return $match[1];
-        }, $conditions);
+        $operators = array_map(fn (array $match) => $match[1], $operators);
+        $conditions = array_map(fn (array $match) => $match[1], $conditions);
 
         $newConditions = [];
         $applied = false;
-        if (is_array($conditions)) {
-            foreach ($conditions as $condition) {
-                foreach ($this->conditionMatchers as $conditionMatcher) {
-                    $condition = trim($condition);
-                    if (! $conditionMatcher->shouldApply($condition)) {
-                        continue;
-                    }
-                    $changedCondition = $conditionMatcher->change($condition);
-                    $applied = true;
-                    if (null !== $changedCondition) {
-                        $newConditions[] = $changedCondition;
-                    }
+        if (!is_array($conditions)) {
+            return;
+        }
+        foreach ($conditions as $condition) {
+            foreach ($this->conditionMatchers as $conditionMatcher) {
+                $condition = trim($condition);
+                if (! $conditionMatcher->shouldApply($condition)) {
+                    continue;
+                }
+                $changedCondition = $conditionMatcher->change($condition);
+                $applied = true;
+                if (null !== $changedCondition) {
+                    $newConditions[] = $changedCondition;
                 }
             }
         }

--- a/src/FileProcessor/TypoScript/TypoScriptFileProcessor.php
+++ b/src/FileProcessor/TypoScript/TypoScriptFileProcessor.php
@@ -101,9 +101,7 @@ final class TypoScriptFileProcessor implements ConfigurableProcessorInterface
 
             $typoscriptRectorsWithChange = array_filter(
                 $this->typoScriptRectors,
-                function (AbstractTypoScriptRector $typoScriptRector) {
-                    return $typoScriptRector->hasChanged();
-                }
+                fn (AbstractTypoScriptRector $typoScriptRector) => $typoScriptRector->hasChanged()
             );
 
             if ([] === $typoscriptRectorsWithChange) {
@@ -154,9 +152,8 @@ final class TypoScriptFileProcessor implements ConfigurableProcessorInterface
      */
     private function convertToPhpFileRectors(): array
     {
-        return array_filter($this->typoScriptRectors, function (Visitor $visitor): bool {
-            return is_a($visitor, ConvertToPhpFileInterface::class, true);
-        });
+        return array_filter($this->typoScriptRectors,
+            fn (Visitor $visitor): bool => is_a($visitor, ConvertToPhpFileInterface::class, true));
     }
 
     private function convertTypoScriptToPhpFiles(): void

--- a/src/Helper/TcaHelperTrait.php
+++ b/src/Helper/TcaHelperTrait.php
@@ -70,12 +70,7 @@ trait TcaHelperTrait
 
     protected function extractArrayValueByKey(?Node $node, string $key): ?Expr
     {
-        $item = $this->extractArrayItemByKey($node, $key);
-        if (null === $item || null === $item->value) {
-            return null;
-        }
-
-        return $item->value;
+        return $this->extractArrayItemByKey($node, $key)?->value;
     }
 
     protected function hasKeyValuePair(Array_ $configValue, string $configKey, string $expectedValue): bool
@@ -192,7 +187,7 @@ trait TcaHelperTrait
 
             // search the config sub-array for this field
             foreach ($columnConfig->value->items as $configValue) {
-                if (null === $configValue || null === $configValue->key) {
+                if (null === $configValue?->key) {
                     continue;
                 }
 

--- a/src/NodeFactory/ImportExtbaseAnnotationIfMissingFactory.php
+++ b/src/NodeFactory/ImportExtbaseAnnotationIfMissingFactory.php
@@ -24,9 +24,7 @@ final class ImportExtbaseAnnotationIfMissingFactory
 
     public function addExtbaseAliasAnnotationIfMissing(Node $node): void
     {
-        $namespace = $this->betterNodeFinder->findFirstPrevious($node, function (Node $node): bool {
-            return $node instanceof Namespace_;
-        });
+        $namespace = $this->betterNodeFinder->findFirstPrevious($node, fn (Node $node): bool => $node instanceof Namespace_);
 
         $completeImportForPartialAnnotation = new CompleteImportForPartialAnnotation(
             'TYPO3\CMS\Extbase\Annotation',

--- a/src/Rector/v10/v0/RefactorIdnaEncodeMethodToNativeFunctionRector.php
+++ b/src/Rector/v10/v0/RefactorIdnaEncodeMethodToNativeFunctionRector.php
@@ -52,7 +52,7 @@ final class RefactorIdnaEncodeMethodToNativeFunctionRector extends AbstractRecto
         if (! is_string($firstArgumentValue)) {
             return null;
         }
-        if (false === strpos($firstArgumentValue, '@')) {
+        if (!str_contains($firstArgumentValue, '@')) {
             return $this->refactorToNativeFunction($firstArgumentValue);
         }
         return $this->refactorToEmailConcatWithNativeFunction($firstArgumentValue);

--- a/src/Rector/v11/v0/ExtbaseControllerActionsMustReturnResponseInterfaceRector.php
+++ b/src/Rector/v11/v0/ExtbaseControllerActionsMustReturnResponseInterfaceRector.php
@@ -177,9 +177,7 @@ CODE_SAMPLE
      */
     private function extractReturnCalls(ClassMethod $node): array
     {
-        return $this->betterNodeFinder->find((array) $node->stmts, function (Node $node): bool {
-            return $node instanceof Return_;
-        });
+        return $this->betterNodeFinder->find((array) $node->stmts, fn(Node $node): bool => $node instanceof Return_);
     }
 
     private function hasRedirectCall(ClassMethod $node): bool
@@ -202,9 +200,7 @@ CODE_SAMPLE
 
     private function hasExitCall(ClassMethod $node): bool
     {
-        return (bool) $this->betterNodeFinder->find((array) $node->stmts, function (Node $node): bool {
-            return $node instanceof Exit_;
-        });
+        return (bool) $this->betterNodeFinder->find((array) $node->stmts, fn (Node $node): bool => $node instanceof Exit_);
     }
 
     private function alreadyResponseReturnType(ClassMethod $node): bool

--- a/src/Rector/v7/v4/DropAdditionalPaletteRector.php
+++ b/src/Rector/v7/v4/DropAdditionalPaletteRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
         }
 
         $showItemNode = $this->extractArrayItemByKey($typeConfig, 'showitem');
-        if (null === $showItemNode || null === $showItemNode->value) {
+        if (null === $showItemNode?->value) {
             return;
         }
 
@@ -82,7 +82,7 @@ CODE_SAMPLE
         if (
             null === $showItemValue
             || ! is_string($showItemValue)
-            || false === strpos($showItemValue, ';')
+            || !str_contains($showItemValue, ';')
         ) {
             return;
         }

--- a/src/Rector/v7/v5/UseExtPrefixForTcaIconFileRector.php
+++ b/src/Rector/v7/v5/UseExtPrefixForTcaIconFileRector.php
@@ -160,7 +160,7 @@ CODE_SAMPLE
             return;
         }
 
-        if (false !== strpos($pathToFile, '/')) {
+        if (str_contains($pathToFile, '/')) {
             return;
         }
 

--- a/src/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector.php
+++ b/src/Rector/v8/v6/MigrateSpecialConfigurationAndRemoveShowItemStylePointerConfigRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
             return;
         }
 
-        if (false === strpos($showitem, ';')) {
+        if (!str_contains($showitem, ';')) {
             // Continue directly if no semicolon is found
             return;
         }

--- a/src/Rector/v9/v3/ValidateAnnotationRector.php
+++ b/src/Rector/v9/v3/ValidateAnnotationRector.php
@@ -113,7 +113,7 @@ CODE_SAMPLE
 
     private function createPropertyAnnotation(string $validatorAnnotation): PhpDocTagNode
     {
-        if (false !== strpos($validatorAnnotation, '(')) {
+        if (str_contains($validatorAnnotation, '(')) {
             preg_match_all('#(?P<validatorName>.*)\((?P<validatorOptions>.*)\)#', $validatorAnnotation, $matches);
 
             $validator = $matches['validatorName'][0];

--- a/src/Rector/v9/v4/SystemEnvironmentBuilderConstantsRector.php
+++ b/src/Rector/v9/v4/SystemEnvironmentBuilderConstantsRector.php
@@ -69,7 +69,7 @@ final class SystemEnvironmentBuilderConstantsRector extends AbstractRector
 
         $value = self::MAP_CONSTANTS_TO_STRING[$constantsName];
 
-        if (false !== strpos($constantsName, 'T3_ERR')) {
+        if (str_contains($constantsName, 'T3_ERR')) {
             return $this->nodeFactory->createClassConstFetch('TYPO3\CMS\Core\Service\AbstractService', $value);
         }
 

--- a/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommand/AddCommandsToReturnRector.php
+++ b/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommand/AddCommandsToReturnRector.php
@@ -81,15 +81,8 @@ CODE_SAMPLE
 
         $existingCommands = $this->valueResolver->getValue($node->expr) ?? [];
 
-        $commands = array_filter($this->commands, function (string $command) use ($existingCommands) {
-            foreach ($existingCommands as $existingCommand) {
-                if ($existingCommand['class'] === $command) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
+        $commands = array_filter($this->commands, fn (string $command) =>
+            array_reduce($existingCommands, fn($carry, $existingCommand) => $existingCommand['class'] !== $command && $carry, true));
 
         foreach ($commands as $commandName => $command) {
             $node->expr->items[] = new ArrayItem($this->nodeFactory->createArray([

--- a/utils/phpstan/src/Type/ContextGetAspectDynamicReturnTypeExtension.php
+++ b/utils/phpstan/src/Type/ContextGetAspectDynamicReturnTypeExtension.php
@@ -42,31 +42,14 @@ final class ContextGetAspectDynamicReturnTypeExtension implements DynamicMethodR
         }
         /** @var String_ $string */
 
-        switch ($string->value) {
-            case 'date':
-                $type = new ObjectType('TYPO3\CMS\Core\Context\DateTimeAspect');
-                break;
-            case 'visibility':
-                $type = new ObjectType('TYPO3\CMS\Core\Context\VisibilityAspect');
-                break;
-            case 'frontend.user':
-            case 'backend.user':
-                $type = new ObjectType('TYPO3\CMS\Core\Context\UserAspect');
-                break;
-            case 'workspace':
-                $type = new ObjectType('TYPO3\CMS\Core\Context\WorkspaceAspect');
-                break;
-            case 'language':
-                $type = new ObjectType('TYPO3\CMS\Core\Context\LanguageAspect');
-                break;
-            case 'typoscript':
-                $type = new ObjectType('TYPO3\CMS\Core\Context\TypoScriptAspect');
-                break;
-            default:
-                $type = $defaultObjectType;
-                break;
-        }
-
-        return $type;
+        return match($string->value) {
+            'date' => new ObjectType('TYPO3\CMS\Core\Context\DateTimeAspect'),
+            'visibility' => new ObjectType('TYPO3\CMS\Core\Context\VisibilityAspect'),
+            'frontend.user','backend.user' => new ObjectType('TYPO3\CMS\Core\Context\UserAspect'),
+            'workspace' => new ObjectType('TYPO3\CMS\Core\Context\WorkspaceAspect'),
+            'language' => new ObjectType('TYPO3\CMS\Core\Context\LanguageAspect'),
+            'typoscript' => new ObjectType('TYPO3\CMS\Core\Context\TypoScriptAspect'),
+            default => $defaultObjectType,
+        };
     }
 }


### PR DESCRIPTION
This pull request aims to replace old code snippets with new ones.
Doing so is desirable, because it leads to more concise and semantically better speaking code.

The following upgrades have taken place (where applicable):
- replace `strpos` with `str_contains`, in cases where it has been used to check if a string contains another string
- replace `switch` and `if/else`-chains with `match`-expressions, in cases where they have been used to return different values based on some input value
- replace anonymous functions with arrow functions, in cases where they immediately return a result and don't do further processing/checks