### PR TITLE
Add stubs to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,4 +23,4 @@ utils/composer-packages export-ignore
 utils/generator export-ignore
 utils/rules export-ignore
 typo3.constants.php export-ignore
-stubs
+/stubs export-ignore


### PR DESCRIPTION
Hi @sabbelasichon, currently, the longest time to downgrade on `rector` scoping is typo3-rector package. Do you think `stubs` directory needs to be included in the dist? If no, I think it can be registered as export-ignore in `.gitattributes`