### PR TITLE
[DX] Make visibility manipulator explicit inject

### DIFF
--- a/src/Rector/v11/v4/ProvideCObjViaMethodRector.php
+++ b/src/Rector/v11/v4/ProvideCObjViaMethodRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\Astral\ValueObject\NodeBuilder\MethodBuilder;
 use Symplify\Astral\ValueObject\NodeBuilder\ParamBuilder;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -28,6 +29,11 @@ final class ProvideCObjViaMethodRector extends AbstractRector
      * @var string
      */
     private const COBJ = 'cObj';
+
+    public function __construct(
+        private VisibilityManipulator $visibilityManipulator,
+    ) {
+    }
 
     /**
      * @return array<class-string<Node>>


### PR DESCRIPTION
This is an attempt to make `AbstractRector` slimmer and lighter :) services should be injected only when needed. No just because 10 rules use them.

See Rector core change https://github.com/rectorphp/rector-src/pull/1298