### PR TITLE
Update weekly make config/ directory files compatible with php 7.1

### DIFF
--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -19,6 +19,13 @@ jobs:
                         name: "Update composer packages"
                         run: "composer update-composer"
                         branch: 'automated-regenerated-composer-packages'
+                        
+                    -
+                        name: "Update config file to support php 7.1"
+                        run: |
+                            composer install
+                            vendor/bin/rector process config -c vendor/rector/rector-src/build/config/config-downgrade.php 
+                        branch: 'automated-make-config-php71-compatible'
 
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,12 @@
         "optimize-autoloader": true,
         "update-with-dependencies": true,
         "sort-packages": true,
-        "platform-check": false
+        "platform-check": false,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "rector/extension-installer": true,
+            "cweagans/composer-patches": true
+        }
     },
     "scripts": {
         "update-composer": [


### PR DESCRIPTION
@sabbelasichon @TomasVotruba based on my pull request on rector-src at https://github.com/rectorphp/rector-src/pull/1551#issue-1087504280

this is a weekly automatic PR to verify that `typo3-rector/config` directory is always compatible with php 7.1

@sabbelasichon for note ,current weekly error on `Update composer packages` task is unrelated:

https://github.com/sabbelasichon/typo3-rector/runs/4571935671?check_suite_focus=true#step:5:25

```
Script @php vendor/bin/rector add-composer-typo3-extensions-to-config handling the update-composer-packages event returned with error code 137
Script @update-composer-packages was called via update-composer
```