### PR TITLE
Add tests to check against merge of TCA config

### DIFF
--- a/tests/FileProcessor/TypoScript/Expected/Extbase.php.inc
+++ b/tests/FileProcessor/TypoScript/Expected/Extbase.php.inc
@@ -50,6 +50,9 @@ return [
             ],
         ],
     ],
+    \JWeiland\Maps2\Domain\Model\PoiCollection::class => [
+        'tableName' => 'tx_maps2_domain_model_poicollection',
+    ],
     \TYPO3\TtAddress\Domain\Model\Address::class => [
         'tableName' => 'tt_address',
         'subclasses' => [

--- a/tests/FileProcessor/TypoScript/Fixture/Extbase/002_extbase_persistence.txt
+++ b/tests/FileProcessor/TypoScript/Fixture/Extbase/002_extbase_persistence.txt
@@ -51,6 +51,18 @@ config.tx_extbase.persistence.classes {
             }
         }
     }
+    JWeiland\Maps2\Domain\Model\PoiCollection {
+        mapping {
+            tableName = tx_maps2_domain_model_poicollection
+            columns {
+                distance {
+                    config {
+                        type = passthrough
+                    }
+                }
+            }
+        }
+    }
     TYPO3\TtAddress\Domain\Model\Address {
         mapping {
             tableName = tt_address


### PR DESCRIPTION
In TYPO3 9 and below there was an ArrayUtility::mergeRecursiveWithOverrule in Extbase:

```
if (isset($currentClassSettings['mapping']['columns']) && is_array($currentClassSettings['mapping']['columns'])) {
                        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($columnMapping, $currentClassSettings['mapping']['columns'], true, false);
                    }
```

which was often used to individually override TCA by page.

This array merge was completely removed with TYPO3 10. So nothing of all these specials should be migrated into Classes.php