### PR TITLE
Do not use VarExporter anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": ">=8.1",
         "helmich/typo3-typoscript-parser": "dev-master#0ccb3a6",
-        "symfony/var-exporter": "^6.0",
         "symfony/string": "^6.0"
     },
     "require-dev": {

--- a/src/FileProcessor/TypoScript/Rector/ExtbasePersistenceTypoScriptRector.php
+++ b/src/FileProcessor/TypoScript/Rector/ExtbasePersistenceTypoScriptRector.php
@@ -43,6 +43,11 @@ final class ExtbasePersistenceTypoScriptRector extends AbstractTypoScriptRector 
      */
     private const REMOVE_EMPTY_LINES = '/^[ \t]*[\r\n]+/m';
 
+    /**
+     * @var string
+     */
+    private const PROPERTIES = 'properties';
+
     private string $filename;
 
     /**
@@ -132,7 +137,7 @@ CODE_SAMPLE
                 }
             }
 
-            foreach (['properties', 'subclasses'] as $subKey) {
+            foreach ([self::PROPERTIES, 'subclasses'] as $subKey) {
                 if (array_key_exists($subKey, $configuration)) {
                     $subArray->items[] = new ArrayItem($this->nodeFactory->createArray(
                         $configuration[$subKey]
@@ -228,7 +233,7 @@ CODE_SAMPLE
 
         $className = $paths[0];
         if (! array_key_exists($className, self::$persistenceArray)) {
-            self::$persistenceArray[$className]['properties'] = [];
+            self::$persistenceArray[$className][self::PROPERTIES] = [];
         }
 
         $fieldName = $paths[3];
@@ -236,6 +241,6 @@ CODE_SAMPLE
         /** @var ScalarValue $scalar */
         $scalar = $statement->value;
 
-        self::$persistenceArray[$className]['properties'][$scalar->value]['fieldName'] = $fieldName;
+        self::$persistenceArray[$className][self::PROPERTIES][$scalar->value]['fieldName'] = $fieldName;
     }
 }

--- a/src/Template/TemplateFinder.php
+++ b/src/Template/TemplateFinder.php
@@ -25,11 +25,6 @@ final class TemplateFinder
         return $this->createSmartFileInfo('Commands/Commands.tpl');
     }
 
-    public function getExtbasePersistenceConfiguration(): SmartFileInfo
-    {
-        return $this->createSmartFileInfo('Extbase/Persistence.tpl');
-    }
-
     private function createSmartFileInfo(string $template): SmartFileInfo
     {
         return new SmartFileInfo($this->templateDirectory . $template);

--- a/templates/maker/Extbase/Persistence.tpl
+++ b/templates/maker/Extbase/Persistence.tpl
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types = 1);
-
-return __PERSISTENCE_ARRAY__;

--- a/tests/FileProcessor/TypoScript/Expected/Extbase.php.inc
+++ b/tests/FileProcessor/TypoScript/Expected/Extbase.php.inc
@@ -1,14 +1,7 @@
 <?php
-
-declare(strict_types = 1);
-
 return [
     'GeorgRinger\News\Domain\Model\News' => [
-        'subclasses' => [
-            'GeorgRinger\News\Domain\Model\NewsDefault',
-            'GeorgRinger\News\Domain\Model\NewsInternal',
-            'GeorgRinger\News\Domain\Model\NewsExternal',
-        ],
+        'subclasses' => ['GeorgRinger\News\Domain\Model\NewsDefault', 'GeorgRinger\News\Domain\Model\NewsInternal', 'GeorgRinger\News\Domain\Model\NewsExternal'],
     ],
     'GeorgRinger\News\Domain\Model\NewsDefault' => [
         'recordType' => '0',
@@ -27,33 +20,14 @@ return [
     ],
     'GeorgRinger\News\Domain\Model\TtContent' => [
         'tableName' => 'tt_content',
-        'properties' => [
-            'altText' => [
-                'fieldName' => 'altText',
-            ],
-            'titleText' => [
-                'fieldName' => 'titleText',
-            ],
-            'colPos' => [
-                'fieldName' => 'colPos',
-            ],
-            'CType' => [
-                'fieldName' => 'CType',
-            ],
-        ],
+        'properties' => ['altText' => ['fieldName' => 'altText'], 'titleText' => ['fieldName' => 'titleText'], 'colPos' => ['fieldName' => 'colPos'], 'CType' => ['fieldName' => 'CType']],
     ],
     'GeorgRinger\News\Domain\Model\Category' => [
         'tableName' => 'sys_category',
-        'properties' => [
-            'parentcategory' => [
-                'fieldName' => 'parent',
-            ],
-        ],
+        'properties' => ['parentcategory' => ['fieldName' => 'parent']],
     ],
     \Ssch\TYPO3Rector\Tests\FileProcessor\TypoScript\Source\Address::class => [
         'tableName' => 'tt_address',
-        'subclasses' => [
-            'Extension14v\Abook\Domain\Model\Address' => 'Extension14v\Abook\Domain\Model\Address',
-        ],
+        'subclasses' => ['Extension14v\Abook\Domain\Model\Address' => 'Extension14v\Abook\Domain\Model\Address'],
     ],
 ];

--- a/tests/FileProcessor/TypoScript/Expected/Extbase.php.inc
+++ b/tests/FileProcessor/TypoScript/Expected/Extbase.php.inc
@@ -3,29 +3,29 @@
 declare(strict_types = 1);
 
 return [
-    \GeorgRinger\News\Domain\Model\News::class => [
+    'GeorgRinger\News\Domain\Model\News' => [
         'subclasses' => [
-            \GeorgRinger\News\Domain\Model\NewsDefault::class,
-            \GeorgRinger\News\Domain\Model\NewsInternal::class,
-            \GeorgRinger\News\Domain\Model\NewsExternal::class,
+            'GeorgRinger\News\Domain\Model\NewsDefault',
+            'GeorgRinger\News\Domain\Model\NewsInternal',
+            'GeorgRinger\News\Domain\Model\NewsExternal',
         ],
     ],
-    \GeorgRinger\News\Domain\Model\NewsDefault::class => [
+    'GeorgRinger\News\Domain\Model\NewsDefault' => [
         'recordType' => '0',
         'tableName' => 'tx_news_domain_model_news',
     ],
-    \GeorgRinger\News\Domain\Model\NewsInternal::class => [
+    'GeorgRinger\News\Domain\Model\NewsInternal' => [
         'recordType' => '1',
         'tableName' => 'tx_news_domain_model_news',
     ],
-    \GeorgRinger\News\Domain\Model\NewsExternal::class => [
+    'GeorgRinger\News\Domain\Model\NewsExternal' => [
         'recordType' => '2',
         'tableName' => 'tx_news_domain_model_news',
     ],
-    \GeorgRinger\News\Domain\Model\FileReference::class => [
+    'GeorgRinger\News\Domain\Model\FileReference' => [
         'tableName' => 'sys_file_reference',
     ],
-    \GeorgRinger\News\Domain\Model\TtContent::class => [
+    'GeorgRinger\News\Domain\Model\TtContent' => [
         'tableName' => 'tt_content',
         'properties' => [
             'altText' => [
@@ -42,7 +42,7 @@ return [
             ],
         ],
     ],
-    \GeorgRinger\News\Domain\Model\Category::class => [
+    'GeorgRinger\News\Domain\Model\Category' => [
         'tableName' => 'sys_category',
         'properties' => [
             'parentcategory' => [
@@ -50,10 +50,10 @@ return [
             ],
         ],
     ],
-    \TYPO3\TtAddress\Domain\Model\Address::class => [
+    \Ssch\TYPO3Rector\Tests\FileProcessor\TypoScript\Source\Address::class => [
         'tableName' => 'tt_address',
         'subclasses' => [
-            \Extension14v\Abook\Domain\Model\Address::class => \Extension14v\Abook\Domain\Model\Address::class,
+            'Extension14v\Abook\Domain\Model\Address' => 'Extension14v\Abook\Domain\Model\Address',
         ],
     ],
 ];

--- a/tests/FileProcessor/TypoScript/Fixture/Extbase/002_extbase_persistence.txt
+++ b/tests/FileProcessor/TypoScript/Fixture/Extbase/002_extbase_persistence.txt
@@ -51,7 +51,7 @@ config.tx_extbase.persistence.classes {
             }
         }
     }
-    TYPO3\TtAddress\Domain\Model\Address {
+    Ssch\TYPO3Rector\Tests\FileProcessor\TypoScript\Source\Address {
         mapping {
             tableName = tt_address
             #recordType = 0

--- a/tests/FileProcessor/TypoScript/Fixture/Extbase/002_extbase_persistence.txt
+++ b/tests/FileProcessor/TypoScript/Fixture/Extbase/002_extbase_persistence.txt
@@ -61,3 +61,24 @@ config.tx_extbase.persistence.classes {
         }
     }
 }
+
+plugin.tx_maps2 {
+    persistence {
+        classes {
+            JWeiland\Maps2\Domain\Model\PoiCollection {
+                mapping {
+                    columns {
+                        distance {
+                            config {
+                                type = passthrough
+                            }
+                        }
+                        foo.config {
+                            type = passthrough
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/FileProcessor/TypoScript/Source/Address.php
+++ b/tests/FileProcessor/TypoScript/Source/Address.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\FileProcessor\TypoScript\Source;
+
+final class Address
+{
+}


### PR DESCRIPTION
@TomasVotruba Could get rid of VarExporter by reformatting after prettyPrinting. So one dependency less.

Resolves: #2794 