### PR TITLE
[update] Use stable Hemlich with Symfony 6 support

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -11,7 +11,7 @@ env:
     COMPOSER_ROOT_VERSION: "dev-main"
 
 jobs:
-    rector:
+    phpstan:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2.4.0

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "helmich/typo3-typoscript-parser": "dev-master#0ccb3a6",
+        "helmich/typo3-typoscript-parser": "^2.4.1",
         "symfony/string": "^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
     ],
     "require": {
         "php": ">=8.1",
-        "helmich/typo3-typoscript-parser": "^2.4.1",
+        "helmich/typo3-typoscript-parser": "2.4.1 as dev-master",
         "symfony/string": "^6.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.4",
+        "friendsofphp/php-cs-fixer": "^3.6",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^9.5",
-        "rector/phpstan-rules": "^0.4.17",
+        "rector/phpstan-rules": "^0.4.20",
         "rector/rector-generator": "dev-main",
         "rector/rector-src": "dev-main",
         "symfony/console": "^6.0",

--- a/src/FileProcessor/Yaml/Form/Rector/TranslationFileRector.php
+++ b/src/FileProcessor/Yaml/Form/Rector/TranslationFileRector.php
@@ -91,13 +91,9 @@ CODE_SAMPLE
      */
     private function buildNewTranslations(array $oldTranslations): array
     {
-        $newTranslations = [];
-        foreach ($oldTranslations as $oldTranslationFileKey => $oldTranslationFile) {
-            if (! \str_starts_with($oldTranslationFile, 'EXT:form')) {
-                $newTranslations[$oldTranslationFileKey] = $oldTranslationFile;
-            }
-        }
-
-        return $newTranslations;
+        return array_filter(
+            $oldTranslations,
+            fn ($oldTranslationFile) => ! \str_starts_with($oldTranslationFile, 'EXT:form')
+        );
     }
 }

--- a/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommandRector.php
+++ b/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommandRector.php
@@ -255,7 +255,7 @@ CODE_SAMPLE
      */
     private function findCommandMethods(Class_ $node): array
     {
-        return $this->betterNodeFinder->find($node->stmts, function (Node $node) {
+        return $this->betterNodeFinder->find($node->stmts, function (Node $node): bool {
             if (! $node instanceof ClassMethod) {
                 return false;
             }
@@ -267,7 +267,7 @@ CODE_SAMPLE
             $methodName = $this->getName($node->name);
 
             if (null === $methodName) {
-                return null;
+                return false;
             }
 
             return \str_ends_with($methodName, 'Command');

--- a/tests/FileProcessor/TypoScript/Fixture/TypoScript/conditions.typoscript
+++ b/tests/FileProcessor/TypoScript/Fixture/TypoScript/conditions.typoscript
@@ -16,7 +16,6 @@
 [global]
 -----
 # Comment
-
 [siteLanguage("languageId") == "2"]
 lib.breadcrumb = TEXT
 lib.breadcrumb.value = Foo


### PR DESCRIPTION
- bump to stable gemlich, since no Symfony 6 is supported
- bump helmich deps to Symfony 6 compatible one
