### PR TITLE
bump deps to remove dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "helmich/typo3-typoscript-parser": "2.4.1 as dev-master",
+        "helmich/typo3-typoscript-parser": "^2.4.1",
         "symfony/string": "^6.0"
     },
     "require-dev": {

--- a/utils/composer-packages/tests/Rector/AddPackageVersionRector/config/configured_rule.php
+++ b/utils/composer-packages/tests/Rector/AddPackageVersionRector/config/configured_rule.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use Rector\Composer\ValueObject\PackageAndVersion;
 use Rector\Core\Configuration\Option;
+use Rector\Core\Configuration\ValueObjectInliner;
 use Ssch\TYPO3Rector\ComposerPackages\Rector\AddPackageVersionRector;
 use Ssch\TYPO3Rector\ComposerPackages\ValueObject\ExtensionVersion;
 use Ssch\TYPO3Rector\ComposerPackages\ValueObject\Typo3Version;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/../../../../config/config.php');


### PR DESCRIPTION
Now rector-src and this package use the same tagger version, so we can drop the alias :slightly_smiling_face: 