### PR TITLE
Use $this->nodesToAddCollector-> call directly for addNodes?(?:Before|After)Node call

### DIFF
--- a/src/Rector/v10/v0/BackendUtilityGetViewDomainToPageRouterRector.php
+++ b/src/Rector/v10/v0/BackendUtilityGetViewDomainToPageRouterRector.php
@@ -51,7 +51,7 @@ final class BackendUtilityGetViewDomainToPageRouterRector extends AbstractRector
             $node->args
         ));
 
-        $this->addNodeBeforeNode($siteNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($siteNode, $node);
 
         return $this->nodeFactory->createMethodCall(
             $this->nodeFactory->createMethodCall(new Variable('site'), 'getRouter'),

--- a/src/Rector/v10/v0/ForceTemplateParsingInTsfeAndTemplateServiceRector.php
+++ b/src/Rector/v10/v0/ForceTemplateParsingInTsfeAndTemplateServiceRector.php
@@ -60,7 +60,7 @@ final class ForceTemplateParsingInTsfeAndTemplateServiceRector extends AbstractR
             //$node->var (left side is the target property, so its an assigment to it)
 
             $contextCall = $this->createCallForSettingProperty();
-            $this->addNodeAfterNode($contextCall, $node);
+            $this->nodesToAddCollector->addNodeAfterNode($contextCall, $node);
 
             try {
                 $this->removeNode($node);

--- a/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
+++ b/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
@@ -190,7 +190,10 @@ CODE_SAMPLE
         $this->nodesToAddCollector->addNodeBeforeNode($this->initializeEmptyArray(), $positionNode);
         $this->nodesToAddCollector->addNodeBeforeNode($this->initializePageArguments(), $positionNode);
         $this->nodesToAddCollector->addNodeBeforeNode($this->initializeQueryParams(), $positionNode);
-        $this->nodesToAddCollector->addNodeBeforeNode($this->getRelevantParametersFromCacheHashCalculator(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode(
+            $this->getRelevantParametersFromCacheHashCalculator(),
+            $positionNode
+        );
 
         return new Variable(self::RELEVANT_PARAMETERS_FOR_CACHING_FROM_PAGE_ARGUMENTS);
     }

--- a/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
+++ b/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
@@ -187,10 +187,10 @@ CODE_SAMPLE
     {
         $currentStmts = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         $positionNode = $currentStmts ?? $node;
-        $this->addNodeBeforeNode($this->initializeEmptyArray(), $positionNode);
-        $this->addNodeBeforeNode($this->initializePageArguments(), $positionNode);
-        $this->addNodeBeforeNode($this->initializeQueryParams(), $positionNode);
-        $this->addNodeBeforeNode($this->getRelevantParametersFromCacheHashCalculator(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->initializeEmptyArray(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->initializePageArguments(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->initializeQueryParams(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->getRelevantParametersFromCacheHashCalculator(), $positionNode);
 
         return new Variable(self::RELEVANT_PARAMETERS_FOR_CACHING_FROM_PAGE_ARGUMENTS);
     }

--- a/src/Rector/v10/v1/SendNotifyEmailToMailApiRector.php
+++ b/src/Rector/v10/v1/SendNotifyEmailToMailApiRector.php
@@ -106,17 +106,17 @@ final class SendNotifyEmailToMailApiRector extends AbstractRector
         $currentStmts = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         $positionNode = $currentStmts ?? $node;
 
-        $this->addNodeBeforeNode($this->initializeSuccessVariable(), $positionNode);
-        $this->addNodeBeforeNode($this->initializeMailClass(), $positionNode);
-        $this->addNodeBeforeNode($this->trimMessage($node), $positionNode);
-        $this->addNodeBeforeNode($this->trimSenderName($node), $positionNode);
-        $this->addNodeBeforeNode($this->trimSenderAddress($node), $positionNode);
-        $this->addNodeBeforeNode($this->ifSenderAddress(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->initializeSuccessVariable(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->initializeMailClass(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->trimMessage($node), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->trimSenderName($node), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->trimSenderAddress($node), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->ifSenderAddress(), $positionNode);
 
         $replyTo = isset($node->args[5]) ? $node->args[5]->value : null;
         if (null !== $replyTo) {
-            $this->addNodeBeforeNode($this->parsedReplyTo($replyTo), $positionNode);
-            $this->addNodeBeforeNode($this->methodReplyTo(), $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($this->parsedReplyTo($replyTo), $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($this->methodReplyTo(), $positionNode);
         }
 
         $ifMessageNotEmpty = $this->messageNotEmpty();
@@ -127,7 +127,7 @@ final class SendNotifyEmailToMailApiRector extends AbstractRector
         $ifMessageNotEmpty->stmts[] = $this->ifParsedRecipients();
         $ifMessageNotEmpty->stmts[] = $this->createSuccessTrue();
 
-        $this->addNodeBeforeNode($ifMessageNotEmpty, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifMessageNotEmpty, $positionNode);
 
         return new Variable(self::SUCCESS);
     }

--- a/src/Rector/v10/v2/InjectEnvironmentServiceIfNeededInResponseRector.php
+++ b/src/Rector/v10/v2/InjectEnvironmentServiceIfNeededInResponseRector.php
@@ -70,7 +70,7 @@ final class InjectEnvironmentServiceIfNeededInResponseRector extends AbstractRec
 
         $this->addInjectEnvironmentServiceMethod($node);
         $property = $this->createEnvironmentServiceProperty();
-        $this->addNodeAfterNode(new Nop(), $property);
+        $this->nodesToAddCollector->addNodeAfterNode(new Nop(), $property);
         $this->classInsertManipulator->addAsFirstMethod($node, $property);
 
         return $node;

--- a/src/Rector/v11/v0/ForwardResponseInsteadOfForwardMethodRector.php
+++ b/src/Rector/v11/v0/ForwardResponseInsteadOfForwardMethodRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
 
             $returnForwardResponse = new Return_($forwardResponse);
 
-            $this->addNodeBeforeNode($returnForwardResponse, $forwardMethodCall);
+            $this->nodesToAddCollector->addNodeBeforeNode($returnForwardResponse, $forwardMethodCall);
             $this->removeNode($forwardMethodCall);
         }
 

--- a/src/Rector/v11/v5/FlexFormToolsArrayValueByPathRector.php
+++ b/src/Rector/v11/v5/FlexFormToolsArrayValueByPathRector.php
@@ -60,7 +60,7 @@ final class FlexFormToolsArrayValueByPathRector extends AbstractRector
             'setValueByPath',
             $args
         );
-        $this->addNodeBeforeNode(new Assign($variableNode, $staticCall), $node);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Assign($variableNode, $staticCall), $node);
         $this->removeNode($node);
 
         return $node;

--- a/src/Rector/v8/v1/RefactorVariousGeneralUtilityMethodsRector.php
+++ b/src/Rector/v8/v1/RefactorVariousGeneralUtilityMethodsRector.php
@@ -113,7 +113,7 @@ final class RefactorVariousGeneralUtilityMethodsRector extends AbstractRector
 
         if (self::CONVERT_MICROTIME === $nodeName) {
             $funcCall = $this->nodeFactory->createFuncCall('explode', [new String_(' '), $node->args[0]->value]);
-            $this->addNodeBeforeNode(new Expression(new Assign(new Variable(self::PARTS), $funcCall)), $node);
+            $this->nodesToAddCollector->addNodeBeforeNode(new Expression(new Assign(new Variable(self::PARTS), $funcCall)), $node);
 
             return $this->nodeFactory->createFuncCall('round', [
                 new Mul(new Plus(

--- a/src/Rector/v8/v1/RefactorVariousGeneralUtilityMethodsRector.php
+++ b/src/Rector/v8/v1/RefactorVariousGeneralUtilityMethodsRector.php
@@ -113,7 +113,10 @@ final class RefactorVariousGeneralUtilityMethodsRector extends AbstractRector
 
         if (self::CONVERT_MICROTIME === $nodeName) {
             $funcCall = $this->nodeFactory->createFuncCall('explode', [new String_(' '), $node->args[0]->value]);
-            $this->nodesToAddCollector->addNodeBeforeNode(new Expression(new Assign(new Variable(self::PARTS), $funcCall)), $node);
+            $this->nodesToAddCollector->addNodeBeforeNode(
+                new Expression(new Assign(new Variable(self::PARTS), $funcCall)),
+                $node
+            );
 
             return $this->nodeFactory->createFuncCall('round', [
                 new Mul(new Plus(

--- a/src/Rector/v8/v1/TypoScriptFrontendControllerCharsetConverterRector.php
+++ b/src/Rector/v8/v1/TypoScriptFrontendControllerCharsetConverterRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
                 )
             )
         );
-        $this->addNodeBeforeNode($charsetConverterNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($charsetConverterNode, $node);
     }
 
     private function refactorCsConvObj(MethodCall $node): ?Node

--- a/src/Rector/v8/v5/ContentObjectRendererFileResourceRector.php
+++ b/src/Rector/v8/v5/ContentObjectRendererFileResourceRector.php
@@ -114,7 +114,7 @@ CODE_SAMPLE
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
         if (! $parentNode->var instanceof PropertyFetch) {
             $initializeVariable = new Expression(new Assign($parentNode->var, new String_('')));
-            $this->addNodeBeforeNode($initializeVariable, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($initializeVariable, $node);
         }
     }
 
@@ -125,7 +125,7 @@ CODE_SAMPLE
             $typoscriptFrontendControllerVariable,
             new ArrayDimFetch(new Variable('GLOBALS'), new String_(Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER))
         );
-        $this->addNodeBeforeNode($typoscriptFrontendControllerNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($typoscriptFrontendControllerNode, $node);
     }
 
     private function addFileNameNode(MethodCall $node): void
@@ -138,7 +138,7 @@ CODE_SAMPLE
                 $node->args
             )
         );
-        $this->addNodeBeforeNode($fileNameNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($fileNameNode, $node);
     }
 
     private function addIfNode(MethodCall $node): void
@@ -156,6 +156,6 @@ CODE_SAMPLE
         ));
         $ifNode->stmts[] = new Expression($templateAssignment);
 
-        $this->addNodeBeforeNode($ifNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifNode, $node);
     }
 }

--- a/src/Rector/v8/v7/BackendUtilityGetRecordRawRector.php
+++ b/src/Rector/v8/v7/BackendUtilityGetRecordRawRector.php
@@ -60,10 +60,10 @@ final class BackendUtilityGetRecordRawRector extends AbstractRector
             $this->nodeFactory->createMethodCall(new Variable(self::QUERY_BUILDER), 'getRestrictions'),
             'removeAll'
         );
-        $this->addNodeBeforeNode(new Nop(), $node);
-        $this->addNodeBeforeNode($queryBuilderAssignment, $node);
-        $this->addNodeBeforeNode($queryBuilderRemoveRestrictions, $node);
-        $this->addNodeBeforeNode(new Nop(), $node);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Nop(), $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($queryBuilderAssignment, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($queryBuilderRemoveRestrictions, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Nop(), $node);
         return $this->fetchQueryBuilderResults($firstArgument, $secondArgument, $thirdArgument);
     }
 

--- a/src/Rector/v8/v7/BackendUtilityGetRecordsByFieldToQueryBuilderRector.php
+++ b/src/Rector/v8/v7/BackendUtilityGetRecordsByFieldToQueryBuilderRector.php
@@ -148,7 +148,7 @@ CODE_SAMPLE
         }
 
         $queryBuilderNode = new Assign(new Variable('queryBuilder'), $queryBuilder);
-        $this->addNodeBeforeNode($queryBuilderNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($queryBuilderNode, $positionNode);
     }
 
     private function isVariable(?Arg $queryBuilderArgument): bool
@@ -189,7 +189,7 @@ CODE_SAMPLE
                 ),
             ]
         );
-        $this->addNodeBeforeNode($newNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($newNode, $positionNode);
     }
 
     private function addQueryBuilderDeletedRestrictionNode(
@@ -223,7 +223,7 @@ CODE_SAMPLE
         );
 
         if ($useDeleteClause) {
-            $this->addNodeBeforeNode($deletedRestrictionNode, $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($deletedRestrictionNode, $positionNode);
 
             return;
         }
@@ -235,7 +235,7 @@ CODE_SAMPLE
         $ifNode = new If_($useDeleteClauseArgument->value);
         $ifNode->stmts[] = new Expression($deletedRestrictionNode);
 
-        $this->addNodeBeforeNode($ifNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifNode, $positionNode);
     }
 
     private function addQueryBuilderSelectNode(
@@ -264,7 +264,7 @@ CODE_SAMPLE
             'where',
             [$queryBuilderWhereExpressionNode]
         );
-        $this->addNodeBeforeNode($queryBuilderWhereNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($queryBuilderWhereNode, $positionNode);
     }
 
     private function addQueryWhereNode(string $queryBuilderVariableName, StaticCall $node, Node $positionNode): void
@@ -285,7 +285,7 @@ CODE_SAMPLE
         ]);
 
         if ($whereClause) {
-            $this->addNodeBeforeNode($whereClauseNode, $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($whereClauseNode, $positionNode);
 
             return;
         }
@@ -297,7 +297,7 @@ CODE_SAMPLE
         $ifNode = new If_($whereClauseArgument->value);
         $ifNode->stmts[] = new Expression($whereClauseNode);
 
-        $this->addNodeBeforeNode($ifNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifNode, $positionNode);
     }
 
     private function addQueryGroupByNode(string $queryBuilderVariableName, StaticCall $node, Node $positionNode): void
@@ -318,7 +318,7 @@ CODE_SAMPLE
         ]);
 
         if ($groupBy) {
-            $this->addNodeBeforeNode($groupByNode, $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($groupByNode, $positionNode);
 
             return;
         }
@@ -330,7 +330,7 @@ CODE_SAMPLE
         $ifNode = new If_(new NotIdentical($groupByArgument->value, new String_('')));
         $ifNode->stmts[] = new Expression($groupByNode);
 
-        $this->addNodeBeforeNode($ifNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifNode, $positionNode);
     }
 
     private function addOrderByNode(string $queryBuilderVariableName, StaticCall $node, Node $positionNode): void
@@ -367,7 +367,7 @@ CODE_SAMPLE
         ));
 
         if ($orderBy) {
-            $this->addNodeBeforeNode($orderByNode, $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($orderByNode, $positionNode);
 
             return;
         }
@@ -375,7 +375,7 @@ CODE_SAMPLE
         $ifNode = new If_(new NotIdentical($orderByArgument->value, new String_('')));
         $ifNode->stmts[] = $orderByNode;
 
-        $this->addNodeBeforeNode($ifNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifNode, $positionNode);
     }
 
     private function addLimitNode(string $queryBuilderVariableName, StaticCall $node, Node $positionNode): void
@@ -421,7 +421,7 @@ CODE_SAMPLE
         ));
 
         if ($limit) {
-            $this->addNodeBeforeNode($limitNode, $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($limitNode, $positionNode);
 
             return;
         }
@@ -429,6 +429,6 @@ CODE_SAMPLE
         $ifNode = new If_(new NotIdentical($limitArgument->value, new String_('')));
         $ifNode->stmts[] = $limitNode;
 
-        $this->addNodeBeforeNode($ifNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifNode, $positionNode);
     }
 }

--- a/src/Rector/v8/v7/RefactorGraphicalFunctionsTempPathAndCreateTemSubDirRector.php
+++ b/src/Rector/v8/v7/RefactorGraphicalFunctionsTempPathAndCreateTemSubDirRector.php
@@ -160,7 +160,7 @@ CODE_SAMPLE
 
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
-        $this->addNodeBeforeNode(
+        $this->nodesToAddCollector->addNodeBeforeNode(
             new Expression(new Assign(new Variable(self::CREATE_TEMP_SUB_DIR), $anonymousFunction)),
             $parentNode
         );

--- a/src/Rector/v8/v7/RefactorPrintContentMethodsRector.php
+++ b/src/Rector/v8/v7/RefactorPrintContentMethodsRector.php
@@ -59,7 +59,7 @@ final class RefactorPrintContentMethodsRector extends AbstractRector
             $this->removeNode($parentNode);
         }
 
-        $this->addNodeBeforeNode($newNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($newNode, $node);
 
         return $node;
     }

--- a/src/Rector/v9/v0/DatabaseConnectionToDbalRector.php
+++ b/src/Rector/v9/v0/DatabaseConnectionToDbalRector.php
@@ -54,7 +54,7 @@ final class DatabaseConnectionToDbalRector extends AbstractRector
             if ($databaseConnectionRefactoring->canHandle($methodName)) {
                 $nodes = $databaseConnectionRefactoring->refactor($node);
                 foreach ($nodes as $newNode) {
-                    $this->addNodeBeforeNode($newNode, $node);
+                    $this->nodesToAddCollector->addNodeBeforeNode($newNode, $node);
                 }
 
                 $this->removeNode($node);

--- a/src/Rector/v9/v0/SubstituteCacheWrapperMethodsRector.php
+++ b/src/Rector/v9/v0/SubstituteCacheWrapperMethodsRector.php
@@ -140,7 +140,10 @@ CODE_SAMPLE
         )));
         $this->nodesToAddCollector->addNodeAfterNode($ifNode, $node);
 
-        $this->nodesToAddCollector->addNodeAfterNode(new Assign(new Variable('content'), new Variable(self::HASH_CONTENT)), $node);
+        $this->nodesToAddCollector->addNodeAfterNode(
+            new Assign(new Variable('content'), new Variable(self::HASH_CONTENT)),
+            $node
+        );
     }
 
     private function addCacheManagerNode(StaticCall $node): void

--- a/src/Rector/v9/v0/SubstituteCacheWrapperMethodsRector.php
+++ b/src/Rector/v9/v0/SubstituteCacheWrapperMethodsRector.php
@@ -129,24 +129,24 @@ CODE_SAMPLE
             'get',
             [$node->args[0]]
         ));
-        $this->addNodeAfterNode($cacheEntryNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($cacheEntryNode, $node);
 
         $hashContentNode = new Assign(new Variable(self::HASH_CONTENT), $this->nodeFactory->createNull());
-        $this->addNodeAfterNode($hashContentNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($hashContentNode, $node);
 
         $ifNode = new If_(new Variable(self::CACHE_ENTRY));
         $ifNode->stmts[] = new Expression(new Assign(new Variable(self::HASH_CONTENT), new Variable(
             self::CACHE_ENTRY
         )));
-        $this->addNodeAfterNode($ifNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($ifNode, $node);
 
-        $this->addNodeAfterNode(new Assign(new Variable('content'), new Variable(self::HASH_CONTENT)), $node);
+        $this->nodesToAddCollector->addNodeAfterNode(new Assign(new Variable('content'), new Variable(self::HASH_CONTENT)), $node);
     }
 
     private function addCacheManagerNode(StaticCall $node): void
     {
         $cacheManagerNode = new Assign(new Variable(self::CACHE_MANAGER), $this->createCacheManager());
-        $this->addNodeAfterNode($cacheManagerNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($cacheManagerNode, $node);
     }
 
     private function setCacheMethod(StaticCall $node): void
@@ -165,6 +165,6 @@ CODE_SAMPLE
             'set',
             $arguments
         );
-        $this->addNodeAfterNode($cacheEntryNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($cacheEntryNode, $node);
     }
 }

--- a/src/Rector/v9/v0/UseLogMethodInsteadOfNewLog2Rector.php
+++ b/src/Rector/v9/v0/UseLogMethodInsteadOfNewLog2Rector.php
@@ -61,14 +61,14 @@ final class UseLogMethodInsteadOfNewLog2Rector extends AbstractRector
                 'getRecordProperties',
                 [$node->args[1], $node->args[2]]
             ));
-            $this->addNodeBeforeNode($propArrayNode, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($propArrayNode, $node);
 
             $pidNode = new Expression(new Assign(new Variable(self::PID), new ArrayDimFetch(new Variable(
                 'propArr'
             ), new String_(self::PID))));
-            $this->addNodeBeforeNode($pidNode, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($pidNode, $node);
 
-            $this->addNodeBeforeNode(new Nop(), $node);
+            $this->nodesToAddCollector->addNodeBeforeNode(new Nop(), $node);
         }
 
         $node->name = new Identifier('log');

--- a/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
+++ b/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
@@ -126,7 +126,7 @@ CODE_SAMPLE
         if ($this->isNames($node->name, ['pageUnavailableHandler', 'pageNotFoundHandler', 'pageErrorHandler'])) {
             $newNode = $this->refactorPageErrorHandlerIfPossible($node);
             if (null !== $newNode) {
-                $this->addNodeBeforeNode($newNode, $positionNode);
+                $this->nodesToAddCollector->addNodeBeforeNode($newNode, $positionNode);
                 $this->removeNodeOrParentNode($node);
             }
 
@@ -139,8 +139,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->addNodeBeforeNode($responseNode, $positionNode);
-        $this->addNodeBeforeNode($this->throwException(), $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($responseNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($this->throwException(), $positionNode);
         $this->removeNodeOrParentNode($node);
 
         return $node;

--- a/src/Rector/v9/v3/CopyMethodGetPidForModTSconfigRector.php
+++ b/src/Rector/v9/v3/CopyMethodGetPidForModTSconfigRector.php
@@ -50,7 +50,7 @@ final class CopyMethodGetPidForModTSconfigRector extends AbstractRector
         $tableVariableNode = $node->args[0]->value;
         if ($tableVariableNode instanceof String_) {
             $tableVariableNode = new Variable('table');
-            $this->addNodeBeforeNode(new Assign($tableVariableNode, $node->args[0]->value), $node);
+            $this->nodesToAddCollector->addNodeBeforeNode(new Assign($tableVariableNode, $node->args[0]->value), $node);
         }
 
         return new Ternary(new BooleanAnd(

--- a/src/Rector/v9/v4/RefactorDeprecatedConcatenateMethodsPageRendererRector.php
+++ b/src/Rector/v9/v4/RefactorDeprecatedConcatenateMethodsPageRendererRector.php
@@ -87,7 +87,7 @@ CODE_SAMPLE
         $node->name = new Identifier($firstMethod);
         $node1 = clone $node;
         $node1->name = new Identifier($secondMethod);
-        $this->addNodeAfterNode($node1, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($node1, $node);
         return $node;
     }
 }

--- a/src/Rector/v9/v4/TemplateGetFileNameToFilePathSanitizerRector.php
+++ b/src/Rector/v9/v4/TemplateGetFileNameToFilePathSanitizerRector.php
@@ -84,7 +84,7 @@ final class TemplateGetFileNameToFilePathSanitizerRector extends AbstractRector
 
         $tryCatchNode = new TryCatch([$assignmentNode], $catches);
 
-        $this->addNodeBeforeNode($tryCatchNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($tryCatchNode, $node);
 
         return $node;
     }

--- a/src/Rector/v9/v4/UseClassSchemaInsteadReflectionServiceMethodsRector.php
+++ b/src/Rector/v9/v4/UseClassSchemaInsteadReflectionServiceMethodsRector.php
@@ -193,7 +193,7 @@ CODE_SAMPLE
 
         $currentStmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         $positionNode = $currentStmt ?? $node;
-        $this->addNodeBeforeNode($propertyTagsValuesNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($propertyTagsValuesNode, $positionNode);
 
         return $propertyTagsValuesVariable;
     }
@@ -303,7 +303,7 @@ CODE_SAMPLE
 
         $currentStmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         $positionNode = $currentStmt ?? $node;
-        $this->addNodeBeforeNode($propertyNode, $positionNode);
+        $this->nodesToAddCollector->addNodeBeforeNode($propertyNode, $positionNode);
 
         return new Ternary(
             new Empty_($propertyVariable),
@@ -328,7 +328,7 @@ CODE_SAMPLE
         $closureUse = $tagValue instanceof Variable ? $tagValue : new Variable('tag');
         if (! $tagValue instanceof Variable) {
             $tempVarNode = new Expression(new Assign($closureUse, $tagValue));
-            $this->addNodeBeforeNode($tempVarNode, $node->getAttribute(AttributeKey::PARENT_NODE));
+            $this->nodesToAddCollector->addNodeBeforeNode($tempVarNode, $node->getAttribute(AttributeKey::PARENT_NODE));
         }
 
         $anonymousFunction = new Closure();

--- a/src/Rector/v9/v4/UseGetMenuInsteadOfGetFirstWebPageRector.php
+++ b/src/Rector/v9/v4/UseGetMenuInsteadOfGetFirstWebPageRector.php
@@ -67,7 +67,7 @@ final class UseGetMenuInsteadOfGetFirstWebPageRector extends AbstractRector
         $parentNode->expr = $resetRootLevelPagesNode;
         $ifNode->stmts[] = new Expression($parentNode);
 
-        $this->addNodeBeforeNode($ifNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($ifNode, $node);
 
         try {
             $this->removeNode($node);
@@ -123,6 +123,6 @@ CODE_SAMPLE
             'getMenu',
             [$node->args[0], 'uid', 'sorting', '', false]
         ));
-        $this->addNodeBeforeNode($rootLevelPagesNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($rootLevelPagesNode, $node);
     }
 }

--- a/src/Rector/v9/v5/RefactorProcessOutputRector.php
+++ b/src/Rector/v9/v5/RefactorProcessOutputRector.php
@@ -106,6 +106,6 @@ CODE_SAMPLE
         $node->args[0] = $this->nodeFactory->createArg($response);
 
         $newNode = $this->nodeFactory->createMethodCall($node->var, 'processContentForOutput');
-        $this->addNodeAfterNode($newNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($newNode, $node);
     }
 }


### PR DESCRIPTION
To be able to remove deprecated methods addNodes?(?:Before|After)Node on AbstractRector, ref https://github.com/rectorphp/rector-src/pull/1879