### PR TITLE
[TASK] Align with new TYPO3 documentation standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,11 @@ Apply automatic fixes on your TYPO3 code.
 
 [Rector](https://github.com/rectorphp/rector) aims to provide instant upgrades and instant refactoring of any PHP 5.3+ code. This project adds rectors specific to TYPO3 to help you migrate between TYPO3 releases or keep your code deprecation free.
 
-## Table of Contents
-1. [Examples in action](docs/examples_in_action.md)
-1. [Overview of all rules](docs/all_rectors_overview.md)
-1. [Installation](docs/installation.md)
-1. [Configuration and Processing](docs/configuration_and_processing.md)
-1. [Best practice guide](docs/best_practice_guide.md)
-1. [Beyond PHP - Entering the realm of FileProcessors](docs/beyond_php_file_processors.md)
-1. [Limitations](docs/limitations.md)
-1. [Contribution](docs/contribution.md)
-
-Please also have a look at the documentation for [Rector](https://github.com/rectorphp/rector) itself.
+|                    | URL                                                          |
+|--------------------|--------------------------------------------------------------|
+| **Repository:**    | https://github.com/sabbelasichon/typo3-rector                |
+| **Documentation:** | https://github.com/sabbelasichon/typo3-rector/tree/main/docs |
+| **Packagist:**     | https://packagist.org/packages/ssch/typo3-rector             |
 
 ## Support
 Please post questions to TYPO3 Slack (https://typo3.slack.com) in the channel #ext-typo3-rector.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Latest Stable Version](https://poser.pugx.org/ssch/typo3-rector/v/stable.svg)](https://packagist.org/packages/ssch/typo3-rector)
+[![Total Downloads](https://poser.pugx.org/ssch/typo3-rector/d/total.svg)](https://packagist.org/packages/ssch/typo3-rector)
+[![Monthly Downloads](https://poser.pugx.org/ssch/typo3-rector/d/monthly)](https://packagist.org/packages/ssch/typo3-rector)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/schreiberten)
 
 ## Caution
@@ -10,8 +13,6 @@ This repository (`ssch/typo3-rector`) is for development TYPO3 Rector only.
 Head to [`rectorphp/rector`](http://github.com/rectorphp/rector) for installation.
 
 Apply automatic fixes on your TYPO3 code.
-
-[![Downloads](https://img.shields.io/packagist/dt/ssch/typo3-rector.svg?style=flat-square)](https://packagist.org/packages/ssch/typo3-rector)
 
 [Rector](https://github.com/rectorphp/rector) aims to provide instant upgrades and instant refactoring of any PHP 5.3+ code. This project adds rectors specific to TYPO3 to help you migrate between TYPO3 releases or keep your code deprecation free.
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,17 @@
 [![Monthly Downloads](https://poser.pugx.org/ssch/typo3-rector/d/monthly)](https://packagist.org/packages/ssch/typo3-rector)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/schreiberten)
 
-## Caution
-
-Never run this tool on production, only on development environment where code is under version control (e.g. git). Always review and test automatic changes before releasing to production.
+:heavy_exclamation_mark: *Caution:* Never run this tool on production, only on development environment where code is under version
+control (e.g. git). Always review and test automatic changes before releasing to production.
 
 # Rector for TYPO3
 
-This repository (`ssch/typo3-rector`) is for development TYPO3 Rector only.
-Head to [`rectorphp/rector`](http://github.com/rectorphp/rector) for installation.
+This project lets you apply instant upgrades and instant refactoring to your [TYPO3 Core](https://get.typo3.org/) and
+[extension](https://extensions.typo3.org) code, making it easier to migrate between TYPO3 releases and keeping your code
+free from deprecation.
 
-Apply automatic fixes on your TYPO3 code.
-
-[Rector](https://github.com/rectorphp/rector) aims to provide instant upgrades and instant refactoring of any PHP 5.3+ code. This project adds rectors specific to TYPO3 to help you migrate between TYPO3 releases or keep your code deprecation free.
+It extends the [Rector](https://github.com/rectorphp/rector) project, which aims to provide instant upgrades and instant
+refactoring for any PHP code (5.3+).
 
 |                    | URL                                                          |
 |--------------------|--------------------------------------------------------------|
@@ -23,12 +22,13 @@ Apply automatic fixes on your TYPO3 code.
 | **Packagist:**     | https://packagist.org/packages/ssch/typo3-rector             |
 
 ## Support
-Please post questions to TYPO3 Slack (https://typo3.slack.com) in the channel #ext-typo3-rector.
-Or feel free to open an issue or start a discussion on github.
+
+Please post questions in the TYPO3 Slack channel [#ext-typo3-rector](https://typo3.slack.com/archives/C019R5LAA6A)
+or feel free to open an issue or start a discussion on GitHub.
 
 ## Credits
 
-Many thanks to [Tomas Votruba](https://tomasvotruba.com) for his on going support and [Rector](https://github.com/rectorphp/rector).
+Many thanks to [Tomas Votruba](https://tomasvotruba.com) for his ongoing support and Rector.
 Many thanks to every other contributor.
 
 Oh, and if you've come down this far, you might as well follow me on [twitter](https://twitter.com/schreiberten).
@@ -37,6 +37,9 @@ Oh, and if you've come down this far, you might as well follow me on [twitter](h
 
 ### How to Apply Coding Standards?
 
-Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an *abstract syntax tree* (AST). An AST doesn't know about spaces and when written to a file it produces poorly formatted code in both PHP and docblock annotations. **That's why your project needs to have a coding standard tool** and a set of formatting rules, so it can make Rector's output code nice and shiny again.
+Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an
+*abstract syntax tree* (AST). An AST doesn't know about spaces and when written to a file it produces poorly formatted
+code in both PHP and docblock annotations. **That's why your project needs to have a coding standard tool** and a set of
+formatting rules, so it can make Rector's output code nice and shiny again.
 
 We're using [ECS](https://github.com/symplify/easy-coding-standard) with [this setup](ecs.php).

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,13 @@
     "name": "ssch/typo3-rector",
     "type": "rector-extension",
     "description": "Instant fixes for your TYPO3 code by using Rector.",
+    "homepage": "https://packagist.org/packages/ssch/typo3-rector",
+    "support": {
+        "docs": "https://github.com/sabbelasichon/typo3-rector/tree/main/docs",
+        "issues": "https://github.com/sabbelasichon/typo3-rector/issues",
+        "source": "https://github.com/sabbelasichon/typo3-rector",
+        "chat": "https://typo3.slack.com/archives/C019R5LAA6A"
+    },
     "license": "MIT",
     "authors": [
         {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation of Rector for TYPO3
+
+1. [Examples in action](examples_in_action.md)
+2. [Overview of all rules](all_rectors_overview.md)
+3. [Installation](installation.md)
+4. [Configuration and Processing](configuration_and_processing.md)
+5. [Best practice guide](best_practice_guide.md)
+6. [Beyond PHP - Entering the realm of FileProcessors](beyond_php_file_processors.md)
+7. [Limitations](limitations.md)
+8. [Contribution](contribution.md)
+
+Please also have a look at the documentation for [Rector](https://github.com/rectorphp/rector) itself.


### PR DESCRIPTION
Hi Sebastian,

this PR is a suggestion to align your package documentation with the recently introduced [TYPO3 documentation standards](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html).

I mainly reworked some content, moved your documentation TOC to /docs, added some badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

Greetings, Alex

Relates: TYPO3-Documentation/T3DocTeam#182
Relates: TYPO3-Documentation/T3DocTeam#185