### PR TITLE
Fix test Call to undefined method Rector\Config\RectorConfig::rule() error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^9.5",
         "rector/phpstan-rules": "^0.4.20",
         "rector/rector-generator": "dev-main",
-        "rector/rector-src": "dev-main#4c6e22b",
+        "rector/rector-src": "dev-main",
         "symfony/console": "^6.0",
         "symplify/coding-standard": "^10.1",
         "symplify/easy-coding-standard": "^10.1",


### PR DESCRIPTION
Fixing error in tests

```

380) Ssch\TYPO3Rector\Rules\Tests\Rector\Misc\AddCodeCoverageIgnoreToMethodRectorDefinitionRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Symfony\Component\Config\Exception\LoaderLoadException: Call to undefined method "Rector\Config\RectorConfig::rule()" in /home/runner/work/rector-src/rector-src/vendor/rector/rector-nette/config/config.php (which is being imported from "/home/runner/work/rector-src/rector-src/vendor/rector/rector-src/src/Kernel/../../config/config.php").
```