### PR TITLE
[rector] Improve usage of PHP sets (e.g. readonly) and make variable name respect node type

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -17,6 +17,7 @@ use Ssch\TYPO3Rector\Rules\Rector\Misc\AddCodeCoverageIgnoreToMethodRectorDefini
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/config/config.php');
 
+    $rectorConfig->parallel();
     $rectorConfig->importNames();
     $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
 
@@ -27,11 +28,11 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([__DIR__ . '/utils', __DIR__ . '/src', __DIR__ . '/tests']);
 
     $rectorConfig->sets([
-        SetList::PHP_80,
-        SetList::PHP_74,
+        //        \Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_80,
         SetList::PRIVATIZATION,
         SetList::CODING_STYLE,
         SetList::CODE_QUALITY,
+        // SetList::NAMING,
     ]);
 
     $rectorConfig->skip([
@@ -45,8 +46,9 @@ return static function (RectorConfig $rectorConfig): void {
         '*/Fixture/*',
     ]);
 
-    $rectorConfig->phpVersion(PhpVersion::PHP_80);
+    $rectorConfig->phpVersion(PhpVersion::PHP_81);
 
     $rectorConfig->rule(TypedPropertyRector::class);
     $rectorConfig->rule(ClassPropertyAssignToConstructorPromotionRector::class);
+    $rectorConfig->rule(\Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class);
 };

--- a/src/FileProcessor/Composer/Rector/ExtensionComposerRector.php
+++ b/src/FileProcessor/Composer/Rector/ExtensionComposerRector.php
@@ -27,7 +27,7 @@ final class ExtensionComposerRector implements ComposerRectorInterface
     private string $defaultTypo3VersionConstraint = '';
 
     public function __construct(
-        private CurrentFileProvider $currentFileProvider
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 

--- a/src/FileProcessor/FlexForms/FlexFormsProcessor.php
+++ b/src/FileProcessor/FlexForms/FlexFormsProcessor.php
@@ -25,8 +25,8 @@ final class FlexFormsProcessor implements FileProcessorInterface
      * @param FlexFormRectorInterface[] $flexFormRectors
      */
     public function __construct(
-        private array $flexFormRectors,
-        private FileDiffFactory $fileDiffFactory,
+        private readonly array $flexFormRectors,
+        private readonly FileDiffFactory $fileDiffFactory,
     ) {
     }
 

--- a/src/FileProcessor/Fluid/FluidFileProcessor.php
+++ b/src/FileProcessor/Fluid/FluidFileProcessor.php
@@ -22,8 +22,8 @@ final class FluidFileProcessor implements FileProcessorInterface
      * @param FluidRectorInterface[] $fluidRectors
      */
     public function __construct(
-        private array $fluidRectors,
-        private FileDiffFactory $fileDiffFactory,
+        private readonly array $fluidRectors,
+        private readonly FileDiffFactory $fileDiffFactory,
     ) {
     }
 

--- a/src/FileProcessor/Resources/Icons/IconsFileProcessor.php
+++ b/src/FileProcessor/Resources/Icons/IconsFileProcessor.php
@@ -31,9 +31,9 @@ final class IconsFileProcessor implements FileProcessorInterface
      * @param IconRectorInterface[] $iconsRector
      */
     public function __construct(
-        private FilesFinder $filesFinder,
-        private SmartFileSystem $smartFileSystem,
-        private array $iconsRector
+        private readonly FilesFinder $filesFinder,
+        private readonly SmartFileSystem $smartFileSystem,
+        private readonly array $iconsRector
     ) {
     }
 

--- a/src/FileProcessor/Resources/Icons/Rector/IconsRector.php
+++ b/src/FileProcessor/Resources/Icons/Rector/IconsRector.php
@@ -18,9 +18,9 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 final class IconsRector implements IconRectorInterface
 {
     public function __construct(
-        private ParameterProvider $parameterProvider,
-        private RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
-        private SmartFileSystem $smartFileSystem
+        private readonly ParameterProvider $parameterProvider,
+        private readonly RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
+        private readonly SmartFileSystem $smartFileSystem
     ) {
     }
 

--- a/src/FileProcessor/TypoScript/Rector/ExtbasePersistenceTypoScriptRector.php
+++ b/src/FileProcessor/TypoScript/Rector/ExtbasePersistenceTypoScriptRector.php
@@ -56,9 +56,9 @@ final class ExtbasePersistenceTypoScriptRector extends AbstractTypoScriptRector 
     private static array $persistenceArray = [];
 
     public function __construct(
-        private ReflectionProvider $reflectionProvider,
-        private BetterStandardPrinter $betterStandardPrinter,
-        private NodeFactory $nodeFactory
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly BetterStandardPrinter $betterStandardPrinter,
+        private readonly NodeFactory $nodeFactory
     ) {
         $this->filename = getcwd() . '/Configuration_Extbase_Persistence_Classes.php';
     }

--- a/src/FileProcessor/TypoScript/Rector/FileIncludeToImportStatementTypoScriptRector.php
+++ b/src/FileProcessor/TypoScript/Rector/FileIncludeToImportStatementTypoScriptRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class FileIncludeToImportStatementTypoScriptRector extends AbstractTypoScriptRector
 {
     public function __construct(
-        private CurrentFileProvider $currentFileProvider
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 

--- a/src/FileProcessor/TypoScript/Rector/OldConditionToExpressionLanguageTypoScriptRector.php
+++ b/src/FileProcessor/TypoScript/Rector/OldConditionToExpressionLanguageTypoScriptRector.php
@@ -24,8 +24,8 @@ final class OldConditionToExpressionLanguageTypoScriptRector extends AbstractTyp
      * @param TyposcriptConditionMatcher[] $conditionMatchers
      */
     public function __construct(
-        private CurrentFileProvider $currentFileProvider,
-        private array $conditionMatchers = []
+        private readonly CurrentFileProvider $currentFileProvider,
+        private readonly array $conditionMatchers = []
     ) {
     }
 

--- a/src/FileProcessor/TypoScript/TypoScriptFileProcessor.php
+++ b/src/FileProcessor/TypoScript/TypoScriptFileProcessor.php
@@ -57,16 +57,16 @@ final class TypoScriptFileProcessor implements ConfigurableProcessorInterface
      * @param TypoScriptPostRectorInterface[] $typoScriptPostRectors
      */
     public function __construct(
-        private ParserInterface $typoscriptParser,
-        private BufferedOutput $output,
-        private ASTPrinterInterface $typoscriptPrinter,
-        private CurrentFileProvider $currentFileProvider,
-        private EditorConfigParser $editorConfigParser,
-        private RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
-        private RectorOutputStyle $rectorOutputStyle,
-        private FileDiffFactory $fileDiffFactory,
-        private array $typoScriptRectors = [],
-        private array $typoScriptPostRectors = []
+        private readonly ParserInterface $typoscriptParser,
+        private readonly BufferedOutput $output,
+        private readonly ASTPrinterInterface $typoscriptPrinter,
+        private readonly CurrentFileProvider $currentFileProvider,
+        private readonly EditorConfigParser $editorConfigParser,
+        private readonly RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
+        private readonly RectorOutputStyle $rectorOutputStyle,
+        private readonly FileDiffFactory $fileDiffFactory,
+        private readonly array $typoScriptRectors = [],
+        private readonly array $typoScriptPostRectors = []
     ) {
     }
 

--- a/src/FileProcessor/Yaml/Form/FormYamlFileProcessor.php
+++ b/src/FileProcessor/Yaml/Form/FormYamlFileProcessor.php
@@ -30,10 +30,10 @@ final class FormYamlFileProcessor implements FileProcessorInterface
      * @param FormYamlRectorInterface[] $transformer
      */
     public function __construct(
-        private CurrentFileProvider $currentFileProvider,
-        private FileDiffFactory $fileDiffFactory,
-        private YamlIndentResolver $yamlIndentResolver,
-        private array $transformer
+        private readonly CurrentFileProvider $currentFileProvider,
+        private readonly FileDiffFactory $fileDiffFactory,
+        private readonly YamlIndentResolver $yamlIndentResolver,
+        private readonly array $transformer
     ) {
     }
 

--- a/src/FileProcessor/Yaml/Form/Rector/EmailFinisherRector.php
+++ b/src/FileProcessor/Yaml/Form/Rector/EmailFinisherRector.php
@@ -42,7 +42,7 @@ final class EmailFinisherRector implements FormYamlRectorInterface
     private const VARIANTS = 'variants';
 
     public function __construct(
-        private CurrentFileProvider $currentFileProvider
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 

--- a/src/Helper/Database/Refactorings/ConnectionCallFactory.php
+++ b/src/Helper/Database/Refactorings/ConnectionCallFactory.php
@@ -12,7 +12,7 @@ use Rector\Core\PhpParser\Node\NodeFactory;
 final class ConnectionCallFactory
 {
     public function __construct(
-        private NodeFactory $nodeFactory
+        private readonly NodeFactory $nodeFactory
     ) {
     }
 

--- a/src/Helper/Database/Refactorings/DatabaseConnectionExecInsertQueryRefactoring.php
+++ b/src/Helper/Database/Refactorings/DatabaseConnectionExecInsertQueryRefactoring.php
@@ -14,8 +14,8 @@ use Ssch\TYPO3Rector\Contract\Helper\Database\Refactorings\DatabaseConnectionToD
 final class DatabaseConnectionExecInsertQueryRefactoring implements DatabaseConnectionToDbalRefactoring
 {
     public function __construct(
-        private ConnectionCallFactory $connectionCallFactory,
-        private NodeFactory $nodeFactory
+        private readonly ConnectionCallFactory $connectionCallFactory,
+        private readonly NodeFactory $nodeFactory
     ) {
     }
 

--- a/src/Helper/Database/Refactorings/DatabaseConnectionExecTruncateTableRefactoring.php
+++ b/src/Helper/Database/Refactorings/DatabaseConnectionExecTruncateTableRefactoring.php
@@ -13,8 +13,8 @@ use Ssch\TYPO3Rector\Contract\Helper\Database\Refactorings\DatabaseConnectionToD
 final class DatabaseConnectionExecTruncateTableRefactoring implements DatabaseConnectionToDbalRefactoring
 {
     public function __construct(
-        private ConnectionCallFactory $connectionCallFactory,
-        private NodeFactory $nodeFactory
+        private readonly ConnectionCallFactory $connectionCallFactory,
+        private readonly NodeFactory $nodeFactory
     ) {
     }
 

--- a/src/Helper/OldSeverityToLogLevelMapper.php
+++ b/src/Helper/OldSeverityToLogLevelMapper.php
@@ -10,7 +10,7 @@ use Rector\Core\PhpParser\Node\NodeFactory;
 final class OldSeverityToLogLevelMapper
 {
     public function __construct(
-        private NodeFactory $nodeFactory
+        private readonly NodeFactory $nodeFactory
     ) {
     }
 

--- a/src/Helper/Typo3NodeResolver.php
+++ b/src/Helper/Typo3NodeResolver.php
@@ -78,9 +78,9 @@ final class Typo3NodeResolver
     public const SIM_ACCESS_TIME = 'SIM_ACCESS_TIME';
 
     public function __construct(
-        private ValueResolver $valueResolver,
-        private NodeNameResolver $nodeNameResolver,
-        private NodeTypeResolver $nodeTypeResolver
+        private readonly ValueResolver $valueResolver,
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/src/NodeAnalyzer/ClassConstAnalyzer.php
+++ b/src/NodeAnalyzer/ClassConstAnalyzer.php
@@ -11,7 +11,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 final class ClassConstAnalyzer
 {
     public function __construct(
-        private NodeNameResolver $nodeNameResolver
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeFactory/HelperArgumentAssignFactory.php
+++ b/src/NodeFactory/HelperArgumentAssignFactory.php
@@ -16,7 +16,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 final class HelperArgumentAssignFactory
 {
     public function __construct(
-        private NodeNameResolver $nodeNameResolver
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeFactory/ImportExtbaseAnnotationIfMissingFactory.php
+++ b/src/NodeFactory/ImportExtbaseAnnotationIfMissingFactory.php
@@ -16,9 +16,9 @@ use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 final class ImportExtbaseAnnotationIfMissingFactory
 {
     public function __construct(
-        private BetterNodeFinder $betterNodeFinder,
-        private  UseNodesToAddCollector $useNodesToAddCollector,
-        private NodeNameResolver $nodeNameResolver
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly UseNodesToAddCollector $useNodesToAddCollector,
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeFactory/InitializeArgumentsClassMethodFactory.php
+++ b/src/NodeFactory/InitializeArgumentsClassMethodFactory.php
@@ -57,15 +57,15 @@ final class InitializeArgumentsClassMethodFactory
     private const MIXED = 'mixed';
 
     public function __construct(
-        private NodeFactory $nodeFactory,
-        private NodeNameResolver $nodeNameResolver,
-        private StaticTypeMapper $staticTypeMapper,
-        private ParamTypeInferer $paramTypeInferer,
-        private PhpDocInfoFactory $phpDocInfoFactory,
-        private ReflectionProvider $reflectionProvider,
-        private ValueResolver $valueResolver,
-        private AstResolver $astResolver,
-        private ClassLikeExistenceChecker $classLikeExistenceChecker
+        private readonly NodeFactory $nodeFactory,
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ParamTypeInferer $paramTypeInferer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ValueResolver $valueResolver,
+        private readonly AstResolver $astResolver,
+        private readonly ClassLikeExistenceChecker $classLikeExistenceChecker
     ) {
     }
 

--- a/src/NodeFactory/InjectMethodFactory.php
+++ b/src/NodeFactory/InjectMethodFactory.php
@@ -26,9 +26,9 @@ use Symplify\Astral\ValueObject\NodeBuilder\ParamBuilder;
 final class InjectMethodFactory
 {
     public function __construct(
-        private NodeNameResolver $nodeNameResolver,
-        private PhpDocTagRemover $phpDocTagRemover,
-        private PhpDocInfoFactory $phpDocInfoFactory
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly PhpDocTagRemover $phpDocTagRemover,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/src/Rector/Experimental/ObjectManagerGetToConstructorInjectionRector.php
+++ b/src/Rector/Experimental/ObjectManagerGetToConstructorInjectionRector.php
@@ -23,8 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ObjectManagerGetToConstructorInjectionRector extends AbstractRector
 {
     public function __construct(
-        private PropertyToAddCollector $propertyToAddCollector,
-        private PropertyNaming $propertyNaming
+        private readonly PropertyToAddCollector $propertyToAddCollector,
+        private readonly PropertyNaming $propertyNaming
     ) {
     }
 

--- a/src/Rector/General/ConvertImplicitVariablesToExplicitGlobalsRector.php
+++ b/src/Rector/General/ConvertImplicitVariablesToExplicitGlobalsRector.php
@@ -20,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ConvertImplicitVariablesToExplicitGlobalsRector extends AbstractRector
 {
     public function __construct(
-        private FilesFinder $filesFinder
+        private readonly FilesFinder $filesFinder
     ) {
     }
 

--- a/src/Rector/General/InjectMethodToConstructorInjectionRector.php
+++ b/src/Rector/General/InjectMethodToConstructorInjectionRector.php
@@ -22,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class InjectMethodToConstructorInjectionRector extends AbstractRector
 {
     public function __construct(
-        private ClassDependencyManipulator $classDependencyManipulator
+        private readonly ClassDependencyManipulator $classDependencyManipulator
     ) {
     }
 

--- a/src/Rector/General/MethodGetInstanceToMakeInstanceCallRector.php
+++ b/src/Rector/General/MethodGetInstanceToMakeInstanceCallRector.php
@@ -98,18 +98,21 @@ CODE_SAMPLE
         $this->classes = $classes;
     }
 
-    private function shouldSkip(StaticCall $node): bool
+    private function shouldSkip(StaticCall $staticCall): bool
     {
         if ([] === $this->classes) {
             return true;
         }
 
-        if (! $this->isName($node->name, 'getInstance')) {
+        if (! $this->isName($staticCall->name, 'getInstance')) {
             return true;
         }
 
         foreach ($this->classes as $class) {
-            if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType($node, new ObjectType($class))) {
+            if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
+                $staticCall,
+                new ObjectType($class)
+            )) {
                 return false;
             }
         }

--- a/src/Rector/Migrations/RenameClassMapAliasRector.php
+++ b/src/Rector/Migrations/RenameClassMapAliasRector.php
@@ -56,8 +56,8 @@ final class RenameClassMapAliasRector extends AbstractRector implements Configur
     ];
 
     public function __construct(
-        private RenamedClassesDataCollector $renamedClassesDataCollector,
-        private ClassRenamer $classRenamer
+        private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
+        private readonly ClassRenamer $classRenamer
     ) {
     }
 

--- a/src/Rector/PostRector/FullQualifiedNamePostRector.php
+++ b/src/Rector/PostRector/FullQualifiedNamePostRector.php
@@ -28,12 +28,12 @@ use Symplify\Skipper\Matcher\FileInfoMatcher;
 final class FullQualifiedNamePostRector extends AbstractPostRector
 {
     public function __construct(
-        private ParameterProvider $parameterProvider,
-        private CurrentFileProvider $currentFileProvider,
-        private BetterNodeFinder $betterNodeFinder,
-        private NodeRemover $nodeRemover,
-        private ClassNameImportSkipper $classNameImportSkipper,
-        private FileInfoMatcher $fileInfoMatcher
+        private readonly ParameterProvider $parameterProvider,
+        private readonly CurrentFileProvider $currentFileProvider,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly NodeRemover $nodeRemover,
+        private readonly ClassNameImportSkipper $classNameImportSkipper,
+        private readonly FileInfoMatcher $fileInfoMatcher
     ) {
         $this->changeNameImportingPostRectorSkipConfiguration($this->parameterProvider);
     }

--- a/src/Rector/v10/v0/ForceTemplateParsingInTsfeAndTemplateServiceRector.php
+++ b/src/Rector/v10/v0/ForceTemplateParsingInTsfeAndTemplateServiceRector.php
@@ -35,7 +35,7 @@ final class ForceTemplateParsingInTsfeAndTemplateServiceRector extends AbstractR
     private const TYPOSCRIPT = 'typoscript';
 
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v10/v0/RemovePropertyExtensionNameRector.php
+++ b/src/Rector/v10/v0/RemovePropertyExtensionNameRector.php
@@ -85,12 +85,18 @@ CODE_SAMPLE
         );
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
-        if ($this->isObjectType($node->var, new ObjectType('TYPO3\CMS\Extbase\Mvc\Controller\AbstractController'))) {
+        if ($this->isObjectType(
+            $propertyFetch->var,
+            new ObjectType('TYPO3\CMS\Extbase\Mvc\Controller\AbstractController')
+        )) {
             return false;
         }
 
-        return ! $this->isObjectType($node->var, new ObjectType('TYPO3\CMS\Extbase\Mvc\Controller\ActionController'));
+        return ! $this->isObjectType(
+            $propertyFetch->var,
+            new ObjectType('TYPO3\CMS\Extbase\Mvc\Controller\ActionController')
+        );
     }
 }

--- a/src/Rector/v10/v0/SetSystemLocaleFromSiteLanguageRector.php
+++ b/src/Rector/v10/v0/SetSystemLocaleFromSiteLanguageRector.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 final class SetSystemLocaleFromSiteLanguageRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v10/v0/SwiftMailerBasedMailMessageToMailerBasedMessageRector.php
+++ b/src/Rector/v10/v0/SwiftMailerBasedMailMessageToMailerBasedMessageRector.php
@@ -102,18 +102,18 @@ CODE_SAMPLE
         ]);
     }
 
-    private function refactorMethodSetBody(MethodCall $node): ?MethodCall
+    private function refactorMethodSetBody(MethodCall $methodCall): ?MethodCall
     {
-        if (! isset($node->args[0])) {
+        if (! isset($methodCall->args[0])) {
             return null;
         }
 
-        if (! $node->args[0]->value instanceof Node) {
+        if (! $methodCall->args[0]->value instanceof Node) {
             return null;
         }
 
-        $bodyType = $this->nodeTypeResolver->getType($node->args[0]->value);
-        $contentType = isset($node->args[1]) ? $this->valueResolver->getValue($node->args[1]->value) : null;
+        $bodyType = $this->nodeTypeResolver->getType($methodCall->args[0]->value);
+        $contentType = isset($methodCall->args[1]) ? $this->valueResolver->getValue($methodCall->args[1]->value) : null;
 
         if (! $bodyType instanceof StringType) {
             return null;
@@ -125,37 +125,37 @@ CODE_SAMPLE
         }
 
         if (null !== $contentType) {
-            unset($node->args[1]);
+            unset($methodCall->args[1]);
         }
 
-        $node->name = new Identifier($methodIdentifier);
+        $methodCall->name = new Identifier($methodIdentifier);
 
-        return $node;
+        return $methodCall;
     }
 
-    private function refactorMethodAddPart(MethodCall $node): ?Node
+    private function refactorMethodAddPart(MethodCall $methodCall): ?Node
     {
-        $contentType = isset($node->args[1]) ? $this->valueResolver->getValue($node->args[1]->value) : null;
+        $contentType = isset($methodCall->args[1]) ? $this->valueResolver->getValue($methodCall->args[1]->value) : null;
 
-        $node->name = new Identifier('text');
+        $methodCall->name = new Identifier('text');
 
         if (! is_string($contentType)) {
             return null;
         }
 
-        unset($node->args[1]);
+        unset($methodCall->args[1]);
 
         if ('text/html' === $contentType) {
-            $node->name = new Identifier('html');
-            return $node;
+            $methodCall->name = new Identifier('html');
+            return $methodCall;
         }
 
-        return $node;
+        return $methodCall;
     }
 
-    private function refactorAttachMethod(MethodCall $node): ?Node
+    private function refactorAttachMethod(MethodCall $methodCall): ?Node
     {
-        $firstArgument = $node->args[0]->value;
+        $firstArgument = $methodCall->args[0]->value;
 
         if (! $firstArgument instanceof StaticCall) {
             return null;
@@ -172,15 +172,15 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->name = new Identifier('attachFromPath');
-        $node->args = $this->nodeFactory->createArgs($firstArgument->args);
+        $methodCall->name = new Identifier('attachFromPath');
+        $methodCall->args = $this->nodeFactory->createArgs($firstArgument->args);
 
-        return $node;
+        return $methodCall;
     }
 
-    private function refactorEmbedMethod(MethodCall $node): ?Node
+    private function refactorEmbedMethod(MethodCall $methodCall): ?Node
     {
-        $firstArgument = $node->args[0]->value;
+        $firstArgument = $methodCall->args[0]->value;
 
         if (! $firstArgument instanceof StaticCall) {
             return null;
@@ -197,9 +197,9 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->name = new Identifier('embedFromPath');
-        $node->args = $this->nodeFactory->createArgs($firstArgument->args);
+        $methodCall->name = new Identifier('embedFromPath');
+        $methodCall->args = $this->nodeFactory->createArgs($firstArgument->args);
 
-        return $node;
+        return $methodCall;
     }
 }

--- a/src/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModulesRector.php
+++ b/src/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModulesRector.php
@@ -173,8 +173,7 @@ CODE_SAMPLE
         StaticCall $staticCall,
         string $vendorName,
         string $extensionName
-    ): void
-    {
+    ): void {
         if (isset($staticCall->args[2]) && $staticCall->args[2]->value instanceof Array_) {
             $this->createNewControllerActionsArray($staticCall->args[2]->value, $vendorName, $extensionName);
         }
@@ -188,8 +187,7 @@ CODE_SAMPLE
         StaticCall $staticCall,
         string $vendorName,
         string $extensionName
-    ): void
-    {
+    ): void {
         if (isset($staticCall->args[4]) && $staticCall->args[4]->value instanceof Array_) {
             $this->createNewControllerActionsArray($staticCall->args[4]->value, $vendorName, $extensionName);
         }

--- a/src/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModulesRector.php
+++ b/src/Rector/v10/v0/UseControllerClassesInExtbasePluginsAndModulesRector.php
@@ -169,21 +169,29 @@ CODE_SAMPLE
         }
     }
 
-    private function refactorConfigurePluginMethod(StaticCall $node, string $vendorName, string $extensionName): void
+    private function refactorConfigurePluginMethod(
+        StaticCall $staticCall,
+        string $vendorName,
+        string $extensionName
+    ): void
     {
-        if (isset($node->args[2]) && $node->args[2]->value instanceof Array_) {
-            $this->createNewControllerActionsArray($node->args[2]->value, $vendorName, $extensionName);
+        if (isset($staticCall->args[2]) && $staticCall->args[2]->value instanceof Array_) {
+            $this->createNewControllerActionsArray($staticCall->args[2]->value, $vendorName, $extensionName);
         }
 
-        if (isset($node->args[3]) && $node->args[3]->value instanceof Array_) {
-            $this->createNewControllerActionsArray($node->args[3]->value, $vendorName, $extensionName);
+        if (isset($staticCall->args[3]) && $staticCall->args[3]->value instanceof Array_) {
+            $this->createNewControllerActionsArray($staticCall->args[3]->value, $vendorName, $extensionName);
         }
     }
 
-    private function refactorRegisterPluginMethod(StaticCall $node, string $vendorName, string $extensionName): void
+    private function refactorRegisterPluginMethod(
+        StaticCall $staticCall,
+        string $vendorName,
+        string $extensionName
+    ): void
     {
-        if (isset($node->args[4]) && $node->args[4]->value instanceof Array_) {
-            $this->createNewControllerActionsArray($node->args[4]->value, $vendorName, $extensionName);
+        if (isset($staticCall->args[4]) && $staticCall->args[4]->value instanceof Array_) {
+            $this->createNewControllerActionsArray($staticCall->args[4]->value, $vendorName, $extensionName);
         }
     }
 

--- a/src/Rector/v10/v0/UseTwoLetterIsoCodeFromSiteLanguageRector.php
+++ b/src/Rector/v10/v0/UseTwoLetterIsoCodeFromSiteLanguageRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseTwoLetterIsoCodeFromSiteLanguageRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
+++ b/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
@@ -50,7 +50,7 @@ final class RefactorInternalPropertiesOfTSFERector extends AbstractRector
     private const QUERY_PARAMS = 'queryParams';
 
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
+++ b/src/Rector/v10/v1/RefactorInternalPropertiesOfTSFERector.php
@@ -109,10 +109,10 @@ CODE_SAMPLE
         return $this->refactorDomainStartPage();
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
         return ! $this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals(
-            $node,
+            $propertyFetch,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         );
     }

--- a/src/Rector/v10/v1/RegisterPluginWithVendorNameRector.php
+++ b/src/Rector/v10/v1/RegisterPluginWithVendorNameRector.php
@@ -70,9 +70,10 @@ final class RegisterPluginWithVendorNameRector extends AbstractRector
         ]);
     }
 
-    private function removeVendorNameIfNeeded(StaticCall $node): ?Node
+    private function removeVendorNameIfNeeded(StaticCall $staticCall): ?Node
     {
-        $extensionNameArgumentValue = $node->args[0]->value;
+        $extensionNameArgumentValue = $staticCall->getArgs()[0]
+            ->value;
 
         $extensionName = $this->valueResolver->getValue($extensionNameArgumentValue);
 
@@ -96,8 +97,8 @@ final class RegisterPluginWithVendorNameRector extends AbstractRector
         }
 
         $extensionName = StringUtility::prepareExtensionName($extensionName, $delimiterPosition);
-        $node->args[0] = $this->nodeFactory->createArg($extensionName);
-        return $node;
+        $staticCall->args[0] = $this->nodeFactory->createArg($extensionName);
+        return $staticCall;
     }
 
     private function isPotentiallyUndefinedExtensionKeyVariable(Concat $extensionNameArgumentValue): bool

--- a/src/Rector/v10/v1/SendNotifyEmailToMailApiRector.php
+++ b/src/Rector/v10/v1/SendNotifyEmailToMailApiRector.php
@@ -186,11 +186,11 @@ CODE_SAMPLE
         )));
     }
 
-    private function trimMessage(MethodCall $node): Node
+    private function trimMessage(MethodCall $methodCall): Node
     {
         return new Assign(new Variable(self::MESSAGE), $this->nodeFactory->createFuncCall(
             self::TRIM,
-            [$node->args[0]]
+            [$methodCall->args[0]]
         ));
     }
 
@@ -202,11 +202,11 @@ CODE_SAMPLE
         )));
     }
 
-    private function trimSenderAddress(MethodCall $node): Node
+    private function trimSenderAddress(MethodCall $methodCall): Node
     {
         return new Expression(new Assign(new Variable(self::SENDER_ADDRESS), $this->nodeFactory->createFuncCall(
             self::TRIM,
-            [$node->args[3]]
+            [$methodCall->args[3]]
         )));
     }
 
@@ -256,7 +256,7 @@ CODE_SAMPLE
         ])));
     }
 
-    private function parsedRecipients(MethodCall $node): Expression
+    private function parsedRecipients(MethodCall $methodCall): Expression
     {
         return new Expression(
             new Assign(
@@ -264,7 +264,7 @@ CODE_SAMPLE
                 $this->nodeFactory->createStaticCall(
                     'TYPO3\CMS\Core\Utility\MailUtility',
                     'parseAddresses',
-                    [$node->args[1]]
+                    [$methodCall->args[1]]
                 )
             )
         );

--- a/src/Rector/v10/v2/ExcludeServiceKeysToArrayRector.php
+++ b/src/Rector/v10/v2/ExcludeServiceKeysToArrayRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ExcludeServiceKeysToArrayRector extends AbstractRector
 {
     public function __construct(
-        private ArrayTypeAnalyzer $arrayTypeAnalyzer
+        private readonly ArrayTypeAnalyzer $arrayTypeAnalyzer
     ) {
     }
 

--- a/src/Rector/v10/v2/ExcludeServiceKeysToArrayRector.php
+++ b/src/Rector/v10/v2/ExcludeServiceKeysToArrayRector.php
@@ -86,17 +86,17 @@ CODE_SAMPLE
         ]);
     }
 
-    private function isExpectedObjectType(StaticCall $node): bool
+    private function isExpectedObjectType(StaticCall $staticCall): bool
     {
         if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $staticCall,
             new ObjectType('TYPO3\CMS\Core\Utility\ExtensionManagementUtility')
         )) {
             return true;
         }
 
         return $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $staticCall,
             new ObjectType('TYPO3\CMS\Core\Utility\GeneralUtility')
         );
     }

--- a/src/Rector/v10/v2/InjectEnvironmentServiceIfNeededInResponseRector.php
+++ b/src/Rector/v10/v2/InjectEnvironmentServiceIfNeededInResponseRector.php
@@ -37,7 +37,7 @@ final class InjectEnvironmentServiceIfNeededInResponseRector extends AbstractRec
     private const ENVIRONMENT_SERVICE = 'environmentService';
 
     public function __construct(
-        private ClassInsertManipulator $classInsertManipulator
+        private readonly ClassInsertManipulator $classInsertManipulator
     ) {
     }
 

--- a/src/Rector/v10/v4/UseIconsFromSubFolderInIconRegistryRector.php
+++ b/src/Rector/v10/v4/UseIconsFromSubFolderInIconRegistryRector.php
@@ -108,9 +108,9 @@ CODE_SAMPLE
         ]);
     }
 
-    private function isSvgIconProvider(MethodCall $node): bool
+    private function isSvgIconProvider(MethodCall $methodCall): bool
     {
-        $iconProviderClassName = $this->valueResolver->getValue($node->args[1]->value);
+        $iconProviderClassName = $this->valueResolver->getValue($methodCall->args[1]->value);
 
         if (null === $iconProviderClassName) {
             return false;

--- a/src/Rector/v11/v0/DateTimeAspectInsteadOfGlobalsExecTimeRector.php
+++ b/src/Rector/v11/v0/DateTimeAspectInsteadOfGlobalsExecTimeRector.php
@@ -18,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DateTimeAspectInsteadOfGlobalsExecTimeRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v11/v0/ExtbaseControllerActionsMustReturnResponseInterfaceRector.php
+++ b/src/Rector/v11/v0/ExtbaseControllerActionsMustReturnResponseInterfaceRector.php
@@ -127,24 +127,24 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(ClassMethod $node): bool
+    private function shouldSkip(ClassMethod $classMethod): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $classMethod,
             new ObjectType('TYPO3\CMS\Extbase\Mvc\Controller\ActionController')
         )) {
             return true;
         }
 
-        if (! $node->isPublic()) {
+        if (! $classMethod->isPublic()) {
             return true;
         }
 
-        if ($node->isAbstract()) {
+        if ($classMethod->isAbstract()) {
             return true;
         }
 
-        $methodName = $this->getName($node->name);
+        $methodName = $this->getName($classMethod->name);
 
         if (null === $methodName) {
             return true;
@@ -158,23 +158,23 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->lastStatementIsExitCall($node)) {
+        if ($this->lastStatementIsExitCall($classMethod)) {
             return true;
         }
 
-        if ($this->hasRedirectCall($node)) {
+        if ($this->hasRedirectCall($classMethod)) {
             return true;
         }
 
-        if ($this->lastStatementIsForwardCall($node)) {
+        if ($this->lastStatementIsForwardCall($classMethod)) {
             return true;
         }
 
-        if ($this->hasExceptionCall($node)) {
+        if ($this->hasExceptionCall($classMethod)) {
             return true;
         }
 
-        return $this->isAlreadyResponseReturnType($node);
+        return $this->isAlreadyResponseReturnType($classMethod);
     }
 
     /**
@@ -185,9 +185,9 @@ CODE_SAMPLE
         return $this->betterNodeFinder->findInstanceOf((array) $classMethod->stmts, Return_::class);
     }
 
-    private function hasRedirectCall(ClassMethod $node): bool
+    private function hasRedirectCall(ClassMethod $classMethod): bool
     {
-        return (bool) $this->betterNodeFinder->find((array) $node->stmts, function (Node $node): bool {
+        return (bool) $this->betterNodeFinder->find((array) $classMethod->stmts, function (Node $node): bool {
             if (! $node instanceof MethodCall) {
                 return false;
             }
@@ -203,20 +203,20 @@ CODE_SAMPLE
         });
     }
 
-    private function lastStatementIsExitCall(ClassMethod $node): bool
+    private function lastStatementIsExitCall(ClassMethod $classMethod): bool
     {
-        if (null === $node->stmts) {
+        if (null === $classMethod->stmts) {
             return false;
         }
 
-        $statements = $node->stmts;
+        $statements = $classMethod->stmts;
         $lastStatement = array_pop($statements);
         return $lastStatement instanceof Expression && $lastStatement->expr instanceof Exit_;
     }
 
-    private function isAlreadyResponseReturnType(ClassMethod $node): bool
+    private function isAlreadyResponseReturnType(ClassMethod $classMethod): bool
     {
-        $returns = $this->findReturns($node);
+        $returns = $this->findReturns($classMethod);
 
         $responseObjectType = new ObjectType('Psr\Http\Message\ResponseInterface');
 
@@ -241,16 +241,16 @@ CODE_SAMPLE
         return false;
     }
 
-    private function hasExceptionCall(ClassMethod $node): bool
+    private function hasExceptionCall(ClassMethod $classMethod): bool
     {
-        if (null === $node->stmts) {
+        if (null === $classMethod->stmts) {
             return false;
         }
 
-        $statements = $node->stmts;
+        $statements = $classMethod->stmts;
         $lastStatement = array_pop($statements);
 
-        if (! ($lastStatement instanceof Throw_)) {
+        if (! $lastStatement instanceof Throw_) {
             return false;
         }
 
@@ -261,13 +261,13 @@ CODE_SAMPLE
             ->yes();
     }
 
-    private function lastStatementIsForwardCall(ClassMethod $node): bool
+    private function lastStatementIsForwardCall(ClassMethod $classMethod): bool
     {
-        if (null === $node->stmts) {
+        if (null === $classMethod->stmts) {
             return false;
         }
 
-        $statements = $node->stmts;
+        $statements = $classMethod->stmts;
         $lastStatement = array_pop($statements);
 
         if (! $lastStatement instanceof Expression) {

--- a/src/Rector/v11/v0/ForwardResponseInsteadOfForwardMethodRector.php
+++ b/src/Rector/v11/v0/ForwardResponseInsteadOfForwardMethodRector.php
@@ -130,9 +130,9 @@ CODE_SAMPLE
     /**
      * @return MethodCall[]
      */
-    private function extractForwardMethodCalls(ClassMethod $node): array
+    private function extractForwardMethodCalls(ClassMethod $classMethod): array
     {
-        return $this->betterNodeFinder->find((array) $node->stmts, function (Node $node): bool {
+        return $this->betterNodeFinder->find((array) $classMethod->stmts, function (Node $node): bool {
             if (! $node instanceof MethodCall) {
                 return false;
             }

--- a/src/Rector/v11/v0/RemoveAddQueryStringMethodRector.php
+++ b/src/Rector/v11/v0/RemoveAddQueryStringMethodRector.php
@@ -22,8 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveAddQueryStringMethodRector extends AbstractRector
 {
     public function __construct(
-        private FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer,
-        private SameClassMethodCallAnalyzer $sameClassMethodCallAnalyzer
+        private readonly FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer,
+        private readonly SameClassMethodCallAnalyzer $sameClassMethodCallAnalyzer
     ) {
     }
 

--- a/src/Rector/v11/v0/RemoveLanguageModeMethodsFromTypo3QuerySettingsRector.php
+++ b/src/Rector/v11/v0/RemoveLanguageModeMethodsFromTypo3QuerySettingsRector.php
@@ -21,8 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveLanguageModeMethodsFromTypo3QuerySettingsRector extends AbstractRector
 {
     public function __construct(
-        private FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer,
-        private SameClassMethodCallAnalyzer $sameClassMethodCallAnalyzer
+        private readonly FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer,
+        private readonly SameClassMethodCallAnalyzer $sameClassMethodCallAnalyzer
     ) {
     }
 

--- a/src/Rector/v11/v0/RemoveLanguageModeMethodsFromTypo3QuerySettingsRector.php
+++ b/src/Rector/v11/v0/RemoveLanguageModeMethodsFromTypo3QuerySettingsRector.php
@@ -75,15 +75,15 @@ CODE_SAMPLE
         ]);
     }
 
-    private function removeMethodCall(MethodCall $node): ?Node
+    private function removeMethodCall(MethodCall $methodCall): ?Node
     {
         try {
             // If it is the only method call, we can safely delete the node here.
-            $this->removeNode($node);
+            $this->removeNode($methodCall);
 
-            return $node;
+            return $methodCall;
         } catch (ShouldNotHappenException) {
-            $chainMethodCalls = $this->fluentChainMethodCallNodeAnalyzer->collectAllMethodCallsInChain($node);
+            $chainMethodCalls = $this->fluentChainMethodCallNodeAnalyzer->collectAllMethodCallsInChain($methodCall);
 
             if (! $this->sameClassMethodCallAnalyzer->haveSingleClass($chainMethodCalls)) {
                 return null;
@@ -94,10 +94,14 @@ CODE_SAMPLE
                     continue;
                 }
 
-                $node->var = new MethodCall($chainMethodCall->var, $chainMethodCall->name, $chainMethodCall->args);
+                $methodCall->var = new MethodCall(
+                    $chainMethodCall->var,
+                    $chainMethodCall->name,
+                    $chainMethodCall->args
+                );
             }
 
-            return $node->var;
+            return $methodCall->var;
         }
     }
 }

--- a/src/Rector/v11/v0/ReplaceInjectAnnotationWithMethodRector.php
+++ b/src/Rector/v11/v0/ReplaceInjectAnnotationWithMethodRector.php
@@ -24,7 +24,7 @@ final class ReplaceInjectAnnotationWithMethodRector extends AbstractRector
     private const OLD_ANNOTATION = 'TYPO3\CMS\Extbase\Annotation\Inject';
 
     public function __construct(
-        private InjectMethodFactory $injectMethodFactory
+        private readonly InjectMethodFactory $injectMethodFactory
     ) {
     }
 

--- a/src/Rector/v11/v0/SubstituteConstantsModeAndRequestTypeRector.php
+++ b/src/Rector/v11/v0/SubstituteConstantsModeAndRequestTypeRector.php
@@ -28,7 +28,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class SubstituteConstantsModeAndRequestTypeRector extends AbstractRector
 {
     public function __construct(
-        private FilesFinder $filesFinder
+        private readonly FilesFinder $filesFinder
     ) {
     }
 

--- a/src/Rector/v11/v2/MigrateFrameModuleToSvgTreeRector.php
+++ b/src/Rector/v11/v2/MigrateFrameModuleToSvgTreeRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class MigrateFrameModuleToSvgTreeRector extends AbstractRector
 {
     public function __construct(
-        private FilesFinder $filesFinder
+        private readonly FilesFinder $filesFinder
     ) {
     }
 

--- a/src/Rector/v11/v3/RemoveBackendUtilityViewOnClickUsageRector.php
+++ b/src/Rector/v11/v3/RemoveBackendUtilityViewOnClickUsageRector.php
@@ -125,15 +125,15 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(StaticCall $node): bool
+    private function shouldSkip(StaticCall $staticCall): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $staticCall,
             new ObjectType('TYPO3\CMS\Backend\Utility\BackendUtility')
         )) {
             return true;
         }
 
-        return ! $this->isName($node->name, 'viewOnClick');
+        return ! $this->isName($staticCall->name, 'viewOnClick');
     }
 }

--- a/src/Rector/v11/v3/RemoveBackendUtilityViewOnClickUsageRector.php
+++ b/src/Rector/v11/v3/RemoveBackendUtilityViewOnClickUsageRector.php
@@ -27,7 +27,7 @@ final class RemoveBackendUtilityViewOnClickUsageRector extends AbstractRector
     private const MESSAGE = 'Rector changed the BackendUtility::viewOnClick call, but further argument resolving is necessary. See Deprecation-91806-BackendUtilityViewOnClick.html and Important-91123-AvoidUsingBackendUtilityViewOnClick.html';
 
     public function __construct(
-        private RectorOutputStyle $rectorOutputStyle
+        private readonly RectorOutputStyle $rectorOutputStyle
     ) {
     }
 

--- a/src/Rector/v11/v3/ReplaceStdAuthCodeWithHmacRector.php
+++ b/src/Rector/v11/v3/ReplaceStdAuthCodeWithHmacRector.php
@@ -24,7 +24,7 @@ final class ReplaceStdAuthCodeWithHmacRector extends AbstractRector
     private const MESSAGE = 'You have to migrate GeneralUtility::stdAuthCode to GeneralUtility::hmac(). To make types work you should check the old function implementation';
 
     public function __construct(
-        private RectorOutputStyle $rectorOutputStyle
+        private readonly RectorOutputStyle $rectorOutputStyle
     ) {
     }
 

--- a/src/Rector/v11/v3/SubstituteMethodRmFromListOfGeneralUtilityRector.php
+++ b/src/Rector/v11/v3/SubstituteMethodRmFromListOfGeneralUtilityRector.php
@@ -23,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class SubstituteMethodRmFromListOfGeneralUtilityRector extends AbstractRector
 {
     public function __construct(
-        private AnonymousFunctionFactory $anonymousFunctionFactory
+        private readonly AnonymousFunctionFactory $anonymousFunctionFactory
     ) {
     }
 

--- a/src/Rector/v11/v3/SwitchBehaviorOfArrayUtilityMethodsRector.php
+++ b/src/Rector/v11/v3/SwitchBehaviorOfArrayUtilityMethodsRector.php
@@ -73,15 +73,15 @@ CODE_SAMPLE
         );
     }
 
-    private function shouldSkip(StaticCall $node): bool
+    private function shouldSkip(StaticCall $staticCall): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $staticCall,
             new ObjectType('TYPO3\CMS\Core\Utility\ArrayUtility')
         )) {
             return true;
         }
 
-        return ! $this->isName($node->name, 'arrayDiffAssocRecursive');
+        return ! $this->isName($staticCall->name, 'arrayDiffAssocRecursive');
     }
 }

--- a/src/Rector/v11/v4/AddSetConfigurationMethodToExceptionHandlerRector.php
+++ b/src/Rector/v11/v4/AddSetConfigurationMethodToExceptionHandlerRector.php
@@ -30,7 +30,7 @@ final class AddSetConfigurationMethodToExceptionHandlerRector extends AbstractRe
     private const SET_CONFIGURATION = 'setConfiguration';
 
     public function __construct(
-        private ReflectionProvider $reflectionProvider
+        private readonly ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/Rector/v11/v4/ProvideCObjViaMethodRector.php
+++ b/src/Rector/v11/v4/ProvideCObjViaMethodRector.php
@@ -31,7 +31,7 @@ final class ProvideCObjViaMethodRector extends AbstractRector
     private const COBJ = 'cObj';
 
     public function __construct(
-        private VisibilityManipulator $visibilityManipulator,
+        private readonly VisibilityManipulator $visibilityManipulator,
     ) {
     }
 

--- a/src/Rector/v11/v4/UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector.php
+++ b/src/Rector/v11/v4/UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector.php
@@ -20,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector extends AbstractRector
 {
     public function __construct(
-        private AstResolver $astResolver
+        private readonly AstResolver $astResolver
     ) {
     }
 

--- a/src/Rector/v11/v4/UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector.php
+++ b/src/Rector/v11/v4/UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector.php
@@ -81,13 +81,13 @@ CODE_SAMPLE
         ]);
     }
 
-    private function extractLengthValue(StaticCall $node): mixed
+    private function extractLengthValue(StaticCall $staticCall): mixed
     {
-        $classMethod = $this->astResolver->resolveClassMethodFromCall($node);
+        $classMethod = $this->astResolver->resolveClassMethodFromCall($staticCall);
 
         $lengthValue = 10;
-        if (isset($node->args[1])) {
-            $lengthValue = $node->args[1]->value;
+        if (isset($staticCall->args[1])) {
+            $lengthValue = $staticCall->args[1]->value;
         } elseif ($classMethod instanceof ClassMethod && null !== $classMethod->params[1]->default) {
             $lengthValue = $this->valueResolver->getValue($classMethod->params[1]->default);
         }

--- a/src/Rector/v11/v5/HandleCObjRendererATagParamsMethodRector.php
+++ b/src/Rector/v11/v5/HandleCObjRendererATagParamsMethodRector.php
@@ -68,15 +68,15 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer')
         )) {
             return true;
         }
 
-        return ! $this->isName($node->name, 'getATagParams');
+        return ! $this->isName($methodCall->name, 'getATagParams');
     }
 }

--- a/src/Rector/v11/v5/RegisterIconToIconFileRector.php
+++ b/src/Rector/v11/v5/RegisterIconToIconFileRector.php
@@ -35,11 +35,11 @@ final class RegisterIconToIconFileRector extends AbstractRector
     private const REMOVE_EMPTY_LINES = '/^[ \t]*[\r\n]+/m';
 
     public function __construct(
-        private FilesFinder $filesFinder,
-        private AddIconsToReturnRector $addIconsToReturnRector,
-        private SimplePhpParser $simplePhpParser,
-        private NodePrinterInterface $nodePrinter,
-        private RemovedAndAddedFilesCollector $removedAndAddedFilesCollector
+        private readonly FilesFinder $filesFinder,
+        private readonly AddIconsToReturnRector $addIconsToReturnRector,
+        private readonly SimplePhpParser $simplePhpParser,
+        private readonly NodePrinterInterface $nodePrinter,
+        private readonly RemovedAndAddedFilesCollector $removedAndAddedFilesCollector
     ) {
     }
 

--- a/src/Rector/v11/v5/ReplaceTSFEATagParamsCallOnGlobalsRector.php
+++ b/src/Rector/v11/v5/ReplaceTSFEATagParamsCallOnGlobalsRector.php
@@ -25,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReplaceTSFEATagParamsCallOnGlobalsRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v11/v5/ReplaceTSFEATagParamsCallOnGlobalsRector.php
+++ b/src/Rector/v11/v5/ReplaceTSFEATagParamsCallOnGlobalsRector.php
@@ -82,28 +82,28 @@ CODE_SAMPLE
         );
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
-        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parentNode = $propertyFetch->getAttribute(AttributeKey::PARENT_NODE);
 
         // Check if we have an assigment to the property, if so do not change it
         if ($parentNode instanceof Assign && $parentNode->var instanceof PropertyFetch) {
             return true;
         }
 
-        if (! $this->isName($node->name, 'ATagParams')) {
+        if (! $this->isName($propertyFetch->name, 'ATagParams')) {
             return true;
         }
 
         if ($this->isObjectType(
-            $node->var,
+            $propertyFetch->var,
             new ObjectType('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController')
         )) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals(
-            $node,
+            $propertyFetch,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         );
     }

--- a/src/Rector/v11/v5/SubstituteBackendTemplateViewWithModuleTemplateRector.php
+++ b/src/Rector/v11/v5/SubstituteBackendTemplateViewWithModuleTemplateRector.php
@@ -46,8 +46,8 @@ final class SubstituteBackendTemplateViewWithModuleTemplateRector extends Abstra
     private const MODULE_TEMPLATE = 'moduleTemplate';
 
     public function __construct(
-        private ClassDependencyManipulator $classDependencyManipulator,
-        private NodesToReplaceCollector $nodesToReplaceCollector
+        private readonly ClassDependencyManipulator $classDependencyManipulator,
+        private readonly NodesToReplaceCollector $nodesToReplaceCollector
     ) {
     }
 

--- a/src/Rector/v11/v5/SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector.php
+++ b/src/Rector/v11/v5/SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector.php
@@ -22,8 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector extends AbstractRector
 {
     public function __construct(
-        private ClassDependencyManipulator $classDependencyManipulator,
-        private NodesToReplaceCollector $nodesToReplaceCollector
+        private readonly ClassDependencyManipulator $classDependencyManipulator,
+        private readonly NodesToReplaceCollector $nodesToReplaceCollector
     ) {
     }
 

--- a/src/Rector/v7/v4/InstantiatePageRendererExplicitlyRector.php
+++ b/src/Rector/v7/v4/InstantiatePageRendererExplicitlyRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class InstantiatePageRendererExplicitlyRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v7/v4/InstantiatePageRendererExplicitlyRector.php
+++ b/src/Rector/v7/v4/InstantiatePageRendererExplicitlyRector.php
@@ -62,31 +62,31 @@ final class InstantiatePageRendererExplicitlyRector extends AbstractRector
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Backend\Controller\BackendController')
         )) {
             return false;
         }
 
         if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Backend\Template\DocumentTemplate')
         )) {
             return false;
         }
 
         if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController')
         )) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isAnyMethodCallOnGlobals(
-            $node,
+            $methodCall,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         );
     }

--- a/src/Rector/v8/v0/GetPreferredClientLanguageRector.php
+++ b/src/Rector/v8/v0/GetPreferredClientLanguageRector.php
@@ -76,24 +76,24 @@ CODE_SAMPLE
         );
     }
 
-    private function isCharsetConverterMethodCall(MethodCall $node): bool
+    private function isCharsetConverterMethodCall(MethodCall $methodCall): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Core\Charset\CharsetConverter')
         )) {
             return false;
         }
 
-        return $this->isName($node->name, self::GET_PREFERRED_CLIENT_LANGUAGE);
+        return $this->isName($methodCall->name, self::GET_PREFERRED_CLIENT_LANGUAGE);
     }
 
-    private function isCallFromTypoScriptFrontendController(MethodCall $node): bool
+    private function isCallFromTypoScriptFrontendController(MethodCall $methodCall): bool
     {
-        if (! $node->var instanceof PropertyFetch) {
+        if (! $methodCall->var instanceof PropertyFetch) {
             return false;
         }
 
-        return $this->isName($node->name, self::GET_PREFERRED_CLIENT_LANGUAGE);
+        return $this->isName($methodCall->name, self::GET_PREFERRED_CLIENT_LANGUAGE);
     }
 }

--- a/src/Rector/v8/v0/RefactorRemovedMethodsFromContentObjectRendererRector.php
+++ b/src/Rector/v8/v0/RefactorRemovedMethodsFromContentObjectRendererRector.php
@@ -106,14 +106,17 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
-        if ($this->isObjectType($node->var, new ObjectType('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer'))) {
+        if ($this->isObjectType(
+            $methodCall->var,
+            new ObjectType('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer')
+        )) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isMethodCallOnPropertyOfGlobals(
-            $node,
+            $methodCall,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER,
             'cObj'
         );

--- a/src/Rector/v8/v0/RemoveLangCsConvObjAndParserFactoryRector.php
+++ b/src/Rector/v8/v0/RemoveLangCsConvObjAndParserFactoryRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveLangCsConvObjAndParserFactoryRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v8/v0/RenderCharsetDefaultsToUtf8Rector.php
+++ b/src/Rector/v8/v0/RenderCharsetDefaultsToUtf8Rector.php
@@ -68,9 +68,9 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
-        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parentNode = $propertyFetch->getAttribute(AttributeKey::PARENT_NODE);
 
         // Check if we have an assigment to the property, if so do not change it
         if ($parentNode instanceof Assign && $parentNode->var instanceof PropertyFetch) {
@@ -78,14 +78,14 @@ CODE_SAMPLE
         }
 
         if ($this->isObjectType(
-            $node->var,
+            $propertyFetch->var,
             new ObjectType('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController')
         )) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals(
-            $node,
+            $propertyFetch,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         );
     }

--- a/src/Rector/v8/v0/RenderCharsetDefaultsToUtf8Rector.php
+++ b/src/Rector/v8/v0/RenderCharsetDefaultsToUtf8Rector.php
@@ -22,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RenderCharsetDefaultsToUtf8Rector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v8/v0/RteHtmlParserRector.php
+++ b/src/Rector/v8/v0/RteHtmlParserRector.php
@@ -90,20 +90,20 @@ CODE_SAMPLE
         );
     }
 
-    private function removeSecondArgumentFromMethod(MethodCall $node): Node
+    private function removeSecondArgumentFromMethod(MethodCall $methodCall): Node
     {
-        $numberOfArguments = count($node->args);
+        $numberOfArguments = count($methodCall->args);
         if ($numberOfArguments > 1) {
-            unset($node->args[1]);
+            unset($methodCall->args[1]);
         }
 
-        return $node;
+        return $methodCall;
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         return ! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Core\Html\RteHtmlParser')
         );
     }

--- a/src/Rector/v8/v0/TimeTrackerGlobalsToSingletonRector.php
+++ b/src/Rector/v8/v0/TimeTrackerGlobalsToSingletonRector.php
@@ -18,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class TimeTrackerGlobalsToSingletonRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v8/v1/TypoScriptFrontendControllerCharsetConverterRector.php
+++ b/src/Rector/v8/v1/TypoScriptFrontendControllerCharsetConverterRector.php
@@ -32,7 +32,7 @@ final class TypoScriptFrontendControllerCharsetConverterRector extends AbstractR
     private const CS_CONV = 'csConv';
 
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v8/v2/UseHtmlSpecialCharsDirectlyForTranslationRector.php
+++ b/src/Rector/v8/v2/UseHtmlSpecialCharsDirectlyForTranslationRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseHtmlSpecialCharsDirectlyForTranslationRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v8/v3/RefactorMethodFileContentRector.php
+++ b/src/Rector/v8/v3/RefactorMethodFileContentRector.php
@@ -71,14 +71,14 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
-        if ($this->isObjectType($node->var, new ObjectType('TYPO3\CMS\Core\TypoScript\TemplateService'))) {
+        if ($this->isObjectType($methodCall->var, new ObjectType('TYPO3\CMS\Core\TypoScript\TemplateService'))) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isMethodCallOnPropertyOfGlobals(
-            $node,
+            $methodCall,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER,
             'tmpl'
         );

--- a/src/Rector/v8/v3/RefactorMethodFileContentRector.php
+++ b/src/Rector/v8/v3/RefactorMethodFileContentRector.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Core\TypoScript\TemplateService;
 final class RefactorMethodFileContentRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v8/v5/CharsetConverterToMultiByteFunctionsRector.php
+++ b/src/Rector/v8/v5/CharsetConverterToMultiByteFunctionsRector.php
@@ -91,16 +91,16 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Core\Charset\CharsetConverter')
         )) {
             return true;
         }
 
-        return ! $this->isNames($node->name, [
+        return ! $this->isNames($methodCall->name, [
             'strlen',
             'convCapitalize',
             'substr',
@@ -110,20 +110,23 @@ CODE_SAMPLE
         ]);
     }
 
-    private function toMultiByteConvertCase(MethodCall $node): FuncCall
+    private function toMultiByteConvertCase(MethodCall $methodCall): FuncCall
     {
         return $this->nodeFactory->createFuncCall(
             'mb_convert_case',
-            [$node->args[1], new ConstFetch(new Name('MB_CASE_TITLE')), $node->args[0]]
+            [$methodCall->args[1], new ConstFetch(new Name('MB_CASE_TITLE')), $methodCall->args[0]]
         );
     }
 
-    private function toMultiByteSubstr(MethodCall $node): FuncCall
+    private function toMultiByteSubstr(MethodCall $methodCall): FuncCall
     {
-        $start = $node->args[2] ?? $this->nodeFactory->createArg(0);
-        $length = $node->args[3] ?? $this->nodeFactory->createNull();
+        $start = $methodCall->args[2] ?? $this->nodeFactory->createArg(0);
+        $length = $methodCall->args[3] ?? $this->nodeFactory->createNull();
 
-        return $this->nodeFactory->createFuncCall('mb_substr', [$node->args[1], $start, $length, $node->args[0]]);
+        return $this->nodeFactory->createFuncCall(
+            'mb_substr',
+            [$methodCall->args[1], $start, $length, $methodCall->args[0]]
+        );
     }
 
     private function toMultiByteLowerUpperCase(MethodCall $node): FuncCall
@@ -145,16 +148,16 @@ CODE_SAMPLE
         );
     }
 
-    private function toMultiByteStrrPos(MethodCall $node): FuncCall
+    private function toMultiByteStrrPos(MethodCall $methodCall): FuncCall
     {
         return $this->nodeFactory->createFuncCall(
             'mb_strrpos',
-            [$node->args[0], $node->args[1], $this->nodeFactory->createArg('utf-8')]
+            [$methodCall->args[0], $methodCall->args[1], $this->nodeFactory->createArg('utf-8')]
         );
     }
 
-    private function toMultiByteStrlen(MethodCall $node): FuncCall
+    private function toMultiByteStrlen(MethodCall $methodCall): FuncCall
     {
-        return $this->nodeFactory->createFuncCall('mb_strlen', array_reverse($node->args));
+        return $this->nodeFactory->createFuncCall('mb_strlen', array_reverse($methodCall->args));
     }
 }

--- a/src/Rector/v8/v5/ContentObjectRendererFileResourceRector.php
+++ b/src/Rector/v8/v5/ContentObjectRendererFileResourceRector.php
@@ -34,7 +34,7 @@ final class ContentObjectRendererFileResourceRector extends AbstractRector
     private const PATH = 'path';
 
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v8/v7/BackendUtilityGetRecordsByFieldToQueryBuilderRector.php
+++ b/src/Rector/v8/v7/BackendUtilityGetRecordsByFieldToQueryBuilderRector.php
@@ -117,14 +117,14 @@ CODE_SAMPLE
         ]);
     }
 
-    private function addQueryBuilderNode(StaticCall $node, Node $positionNode): void
+    private function addQueryBuilderNode(StaticCall $staticCall, Node $positionNode): void
     {
-        $queryBuilderArgument = $node->args[8] ?? null;
+        $queryBuilderArgument = $staticCall->args[8] ?? null;
         if ($this->isVariable($queryBuilderArgument)) {
             return;
         }
 
-        $tableArgument = $node->args[0];
+        $tableArgument = $staticCall->args[0];
 
         if (! $queryBuilderArgument instanceof Arg || 'null' === $this->valueResolver->getValue(
             $queryBuilderArgument->value
@@ -156,9 +156,9 @@ CODE_SAMPLE
         return null !== $queryBuilderArgument && $queryBuilderArgument->value instanceof Variable;
     }
 
-    private function extractQueryBuilderVariableName(StaticCall $node): string
+    private function extractQueryBuilderVariableName(StaticCall $staticCall): string
     {
-        $queryBuilderArgument = $node->args[8] ?? null;
+        $queryBuilderArgument = $staticCall->getArgs()[8] ?? null;
         $queryBuilderVariableName = 'queryBuilder';
         if (null !== $queryBuilderArgument && $this->isVariable($queryBuilderArgument)) {
             $queryBuilderVariableName = $this->getName($queryBuilderArgument->value);

--- a/src/Rector/v8/v7/RefactorGraphicalFunctionsTempPathAndCreateTemSubDirRector.php
+++ b/src/Rector/v8/v7/RefactorGraphicalFunctionsTempPathAndCreateTemSubDirRector.php
@@ -172,17 +172,17 @@ CODE_SAMPLE
         );
     }
 
-    private function refactorPropertyFetch(PropertyFetch $node): ?Node
+    private function refactorPropertyFetch(PropertyFetch $propertyFetch): ?Node
     {
-        if (! $this->isObjectType($node->var, new ObjectType('TYPO3\CMS\Core\Imaging\GraphicalFunctions'))) {
+        if (! $this->isObjectType($propertyFetch->var, new ObjectType('TYPO3\CMS\Core\Imaging\GraphicalFunctions'))) {
             return null;
         }
 
-        if (! $this->isName($node->name, self::TEMP_PATH)) {
+        if (! $this->isName($propertyFetch->name, self::TEMP_PATH)) {
             return null;
         }
 
-        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parentNode = $propertyFetch->getAttribute(AttributeKey::PARENT_NODE);
 
         // Check if we have an assigment to the property, if so do not change it
         if ($parentNode instanceof Assign && $parentNode->var instanceof PropertyFetch) {

--- a/src/Rector/v8/v7/RefactorGraphicalFunctionsTempPathAndCreateTemSubDirRector.php
+++ b/src/Rector/v8/v7/RefactorGraphicalFunctionsTempPathAndCreateTemSubDirRector.php
@@ -91,24 +91,24 @@ CODE_SAMPLE
         ]);
     }
 
-    private function refactorMethodCall(MethodCall $node): ?Node
+    private function refactorMethodCall(MethodCall $methodCall): ?Node
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Core\Imaging\GraphicalFunctions')
         )) {
             return null;
         }
 
-        if (! $this->isName($node->name, self::CREATE_TEMP_SUB_DIR)) {
+        if (! $this->isName($methodCall->name, self::CREATE_TEMP_SUB_DIR)) {
             return null;
         }
 
-        if ([] === $node->args) {
+        if ([] === $methodCall->args) {
             return null;
         }
 
-        $argumentValue = $this->valueResolver->getValue($node->args[0]->value);
+        $argumentValue = $this->valueResolver->getValue($methodCall->args[0]->value);
 
         if (null === $argumentValue) {
             return null;
@@ -158,7 +158,7 @@ CODE_SAMPLE
         $anonymousFunction->stmts[] = $ifIsNotDir;
         $anonymousFunction->stmts[] = new Return_($this->nodeFactory->createFalse());
 
-        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parentNode = $methodCall->getAttribute(AttributeKey::PARENT_NODE);
 
         $this->nodesToAddCollector->addNodeBeforeNode(
             new Expression(new Assign(new Variable(self::CREATE_TEMP_SUB_DIR), $anonymousFunction)),
@@ -168,7 +168,7 @@ CODE_SAMPLE
         // Could not figure how to call the closure like that $function();
         return $this->nodeFactory->createFuncCall(
             'call_user_func',
-            [new Variable(self::CREATE_TEMP_SUB_DIR), new String_('typo3temp'), $node->args[0]->value]
+            [new Variable(self::CREATE_TEMP_SUB_DIR), new String_('typo3temp'), $methodCall->args[0]->value]
         );
     }
 

--- a/src/Rector/v8/v7/RefactorPrintContentMethodsRector.php
+++ b/src/Rector/v8/v7/RefactorPrintContentMethodsRector.php
@@ -98,22 +98,22 @@ CODE_SAMPLE
         );
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
-        if ($this->isPageLayoutControllerClass($node)) {
+        if ($this->isPageLayoutControllerClass($methodCall)) {
             return false;
         }
 
         return ! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Taskcenter\Controller\TaskModuleController')
         );
     }
 
-    private function isPageLayoutControllerClass(MethodCall $node): bool
+    private function isPageLayoutControllerClass(MethodCall $methodCall): bool
     {
         return $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Backend\Controller\PageLayoutController')
         );
     }

--- a/src/Rector/v8/v7/UseCachingFrameworkInsteadGetAndStoreHashRector.php
+++ b/src/Rector/v8/v7/UseCachingFrameworkInsteadGetAndStoreHashRector.php
@@ -23,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseCachingFrameworkInsteadGetAndStoreHashRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v0/DatabaseConnectionToDbalRector.php
+++ b/src/Rector/v9/v0/DatabaseConnectionToDbalRector.php
@@ -96,8 +96,8 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
-        return ! $this->typo3NodeResolver->isAnyMethodCallOnGlobals($node, Typo3NodeResolver::TYPO3_DB);
+        return ! $this->typo3NodeResolver->isAnyMethodCallOnGlobals($methodCall, Typo3NodeResolver::TYPO3_DB);
     }
 }

--- a/src/Rector/v9/v0/DatabaseConnectionToDbalRector.php
+++ b/src/Rector/v9/v0/DatabaseConnectionToDbalRector.php
@@ -23,8 +23,8 @@ final class DatabaseConnectionToDbalRector extends AbstractRector
      * @param DatabaseConnectionToDbalRefactoring[] $databaseConnectionRefactorings
      */
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver,
-        private array $databaseConnectionRefactorings
+        private readonly Typo3NodeResolver $typo3NodeResolver,
+        private readonly array $databaseConnectionRefactorings
     ) {
     }
 

--- a/src/Rector/v9/v0/IgnoreValidationAnnotationRector.php
+++ b/src/Rector/v9/v0/IgnoreValidationAnnotationRector.php
@@ -32,8 +32,8 @@ final class IgnoreValidationAnnotationRector extends AbstractRector
     private const VERY_OLD_ANNOTATION = 'dontvalidate';
 
     public function __construct(
-        private PhpDocTagRemover $phpDocTagRemover,
-        private ImportExtbaseAnnotationIfMissingFactory $importExtbaseAnnotationIfMissingFactory
+        private readonly PhpDocTagRemover $phpDocTagRemover,
+        private readonly ImportExtbaseAnnotationIfMissingFactory $importExtbaseAnnotationIfMissingFactory
     ) {
     }
 

--- a/src/Rector/v9/v0/InjectAnnotationRector.php
+++ b/src/Rector/v9/v0/InjectAnnotationRector.php
@@ -30,8 +30,8 @@ final class InjectAnnotationRector extends AbstractRector
     private const NEW_ANNOTATION = 'TYPO3\CMS\Extbase\Annotation\Inject';
 
     public function __construct(
-        private InjectMethodFactory $injectMethodFactory,
-        private DocBlockTagReplacer $docBlockTagReplacer
+        private readonly InjectMethodFactory $injectMethodFactory,
+        private readonly DocBlockTagReplacer $docBlockTagReplacer
     ) {
     }
 

--- a/src/Rector/v9/v0/MetaTagManagementRector.php
+++ b/src/Rector/v9/v0/MetaTagManagementRector.php
@@ -103,38 +103,38 @@ CODE_SAMPLE
         return [];
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
-        return ! $this->isMethodAddMetaTag($node) && ! $this->isMethodXUaCompatible($node);
+        return ! $this->isMethodAddMetaTag($methodCall) && ! $this->isMethodXUaCompatible($methodCall);
     }
 
-    private function isMethodAddMetaTag(MethodCall $node): bool
+    private function isMethodAddMetaTag(MethodCall $methodCall): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Core\Page\PageRenderer')
         )) {
             return false;
         }
 
-        return $this->isName($node->name, 'addMetaTag');
+        return $this->isName($methodCall->name, 'addMetaTag');
     }
 
-    private function isMethodXUaCompatible(MethodCall $node): bool
+    private function isMethodXUaCompatible(MethodCall $methodCall): bool
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Backend\Template\DocumentTemplate')
         )) {
             return false;
         }
 
-        return $this->isName($node->name, 'xUaCompatible');
+        return $this->isName($methodCall->name, 'xUaCompatible');
     }
 
-    private function createSetMetaTagMethod(MethodCall $node): ?MethodCall
+    private function createSetMetaTagMethod(MethodCall $methodCall): ?MethodCall
     {
-        $arg = $node->args[0];
+        $arg = $methodCall->args[0];
 
         if (! $arg->value instanceof String_) {
             return null;
@@ -151,10 +151,10 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->name = new Identifier('setMetaTag');
-        $node->args = $this->nodeFactory->createArgs(array_values($arguments));
+        $methodCall->name = new Identifier('setMetaTag');
+        $methodCall->args = $this->nodeFactory->createArgs(array_values($arguments));
 
-        return $node;
+        return $methodCall;
     }
 
     private function createXUCompatibleMetaTag(MethodCall $methodCall): MethodCall

--- a/src/Rector/v9/v0/MoveRenderArgumentsToInitializeArgumentsMethodRector.php
+++ b/src/Rector/v9/v0/MoveRenderArgumentsToInitializeArgumentsMethodRector.php
@@ -22,9 +22,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class MoveRenderArgumentsToInitializeArgumentsMethodRector extends AbstractRector
 {
     public function __construct(
-        private HelperArgumentAssignFactory $helperArgumentAssignFactory,
-        private InitializeArgumentsClassMethodFactory $initializeArgumentsClassMethodFactory,
-        private PhpDocTagRemover $phpDocTagRemover
+        private readonly HelperArgumentAssignFactory $helperArgumentAssignFactory,
+        private readonly InitializeArgumentsClassMethodFactory $initializeArgumentsClassMethodFactory,
+        private readonly PhpDocTagRemover $phpDocTagRemover
     ) {
     }
 

--- a/src/Rector/v9/v0/RefactorMethodsFromExtensionManagementUtilityRector.php
+++ b/src/Rector/v9/v0/RefactorMethodsFromExtensionManagementUtilityRector.php
@@ -73,9 +73,9 @@ CODE_SAMPLE
         ]);
     }
 
-    private function createNewMethodCallForSiteRelPath(StaticCall $node): StaticCall
+    private function createNewMethodCallForSiteRelPath(StaticCall $staticCall): StaticCall
     {
-        $firstArgument = $node->args[0];
+        $firstArgument = $staticCall->args[0];
         return $this->nodeFactory->createStaticCall(
             'TYPO3\CMS\Core\Utility\PathUtility',
             'stripPathSitePrefix',
@@ -100,13 +100,13 @@ CODE_SAMPLE
         );
     }
 
-    private function removeSecondArgumentFromMethodIsLoaded(StaticCall $node): Node
+    private function removeSecondArgumentFromMethodIsLoaded(StaticCall $staticCall): Node
     {
-        $numberOfArguments = count($node->args);
+        $numberOfArguments = count($staticCall->args);
         if ($numberOfArguments > 1) {
-            unset($node->args[1]);
+            unset($staticCall->args[1]);
         }
 
-        return $node;
+        return $staticCall;
     }
 }

--- a/src/Rector/v9/v0/ReplaceAnnotationRector.php
+++ b/src/Rector/v9/v0/ReplaceAnnotationRector.php
@@ -34,8 +34,8 @@ final class ReplaceAnnotationRector extends AbstractRector implements Configurab
     private array $oldToNewAnnotations = [];
 
     public function __construct(
-        private PhpDocTagRemover $phpDocTagRemover,
-        private ImportExtbaseAnnotationIfMissingFactory $importExtbaseAnnotationIfMissingFactory
+        private readonly PhpDocTagRemover $phpDocTagRemover,
+        private readonly ImportExtbaseAnnotationIfMissingFactory $importExtbaseAnnotationIfMissingFactory
     ) {
     }
 

--- a/src/Rector/v9/v0/ReplaceExtKeyWithExtensionKeyRector.php
+++ b/src/Rector/v9/v0/ReplaceExtKeyWithExtensionKeyRector.php
@@ -25,7 +25,7 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 final class ReplaceExtKeyWithExtensionKeyRector extends AbstractRector
 {
     public function __construct(
-        private FilesFinder $filesFinder
+        private readonly FilesFinder $filesFinder
     ) {
     }
 

--- a/src/Rector/v9/v0/ReplacedGeneralUtilitySysLogWithLogginApiRector.php
+++ b/src/Rector/v9/v0/ReplacedGeneralUtilitySysLogWithLogginApiRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReplacedGeneralUtilitySysLogWithLogginApiRector extends AbstractRector
 {
     public function __construct(
-        private OldSeverityToLogLevelMapper $oldSeverityToLogLevelMapper
+        private readonly OldSeverityToLogLevelMapper $oldSeverityToLogLevelMapper
     ) {
     }
 

--- a/src/Rector/v9/v0/SubstituteCacheWrapperMethodsRector.php
+++ b/src/Rector/v9/v0/SubstituteCacheWrapperMethodsRector.php
@@ -120,46 +120,46 @@ CODE_SAMPLE
         ]);
     }
 
-    private function getCacheMethod(StaticCall $node): void
+    private function getCacheMethod(StaticCall $staticCall): void
     {
-        $this->addCacheManagerNode($node);
+        $this->addCacheManagerNode($staticCall);
 
         $cacheEntryNode = new Assign(new Variable(self::CACHE_ENTRY), $this->nodeFactory->createMethodCall(
             $this->nodeFactory->createMethodCall(self::CACHE_MANAGER, 'getCache', ['cache_hash']),
             'get',
-            [$node->args[0]]
+            [$staticCall->args[0]]
         ));
-        $this->nodesToAddCollector->addNodeAfterNode($cacheEntryNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($cacheEntryNode, $staticCall);
 
         $hashContentNode = new Assign(new Variable(self::HASH_CONTENT), $this->nodeFactory->createNull());
-        $this->nodesToAddCollector->addNodeAfterNode($hashContentNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($hashContentNode, $staticCall);
 
         $ifNode = new If_(new Variable(self::CACHE_ENTRY));
         $ifNode->stmts[] = new Expression(new Assign(new Variable(self::HASH_CONTENT), new Variable(
             self::CACHE_ENTRY
         )));
-        $this->nodesToAddCollector->addNodeAfterNode($ifNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($ifNode, $staticCall);
 
         $this->nodesToAddCollector->addNodeAfterNode(
             new Assign(new Variable('content'), new Variable(self::HASH_CONTENT)),
-            $node
+            $staticCall
         );
     }
 
-    private function addCacheManagerNode(StaticCall $node): void
+    private function addCacheManagerNode(StaticCall $staticCall): void
     {
         $cacheManagerNode = new Assign(new Variable(self::CACHE_MANAGER), $this->createCacheManager());
-        $this->nodesToAddCollector->addNodeAfterNode($cacheManagerNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($cacheManagerNode, $staticCall);
     }
 
-    private function setCacheMethod(StaticCall $node): void
+    private function setCacheMethod(StaticCall $staticCall): void
     {
-        $this->addCacheManagerNode($node);
+        $this->addCacheManagerNode($staticCall);
 
         $arguments = [
-            $node->args[0],
-            $node->args[1],
-            new Array_([new ArrayItem(new Concat(new String_('ident_'), $node->args[2]->value))]),
+            $staticCall->args[0],
+            $staticCall->args[1],
+            new Array_([new ArrayItem(new Concat(new String_('ident_'), $staticCall->args[2]->value))]),
             $this->nodeFactory->createArg(0),
         ];
 
@@ -168,6 +168,6 @@ CODE_SAMPLE
             'set',
             $arguments
         );
-        $this->nodesToAddCollector->addNodeAfterNode($cacheEntryNode, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($cacheEntryNode, $staticCall);
     }
 }

--- a/src/Rector/v9/v0/SubstituteConstantParsetimeStartRector.php
+++ b/src/Rector/v9/v0/SubstituteConstantParsetimeStartRector.php
@@ -23,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class SubstituteConstantParsetimeStartRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v0/SubstituteGeneralUtilityDevLogRector.php
+++ b/src/Rector/v9/v0/SubstituteGeneralUtilityDevLogRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class SubstituteGeneralUtilityDevLogRector extends AbstractRector
 {
     public function __construct(
-        private OldSeverityToLogLevelMapper $oldSeverityToLogLevelMapper
+        private readonly OldSeverityToLogLevelMapper $oldSeverityToLogLevelMapper
     ) {
     }
 

--- a/src/Rector/v9/v0/UseExtensionConfigurationApiRector.php
+++ b/src/Rector/v9/v0/UseExtensionConfigurationApiRector.php
@@ -27,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseExtensionConfigurationApiRector extends AbstractRector
 {
     public function __construct(
-        private RectorOutputStyle $rectorOutputStyle
+        private readonly RectorOutputStyle $rectorOutputStyle
     ) {
     }
 

--- a/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
+++ b/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
@@ -143,17 +143,17 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         if ($this->typo3NodeResolver->isAnyMethodCallOnGlobals(
-            $node,
+            $methodCall,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         )) {
             return false;
         }
 
         return ! $this->isObjectType(
-            $node->var,
+            $methodCall->var,
             new ObjectType('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController')
         );
     }
@@ -231,13 +231,13 @@ CODE_SAMPLE
         );
     }
 
-    private function refactorPageErrorHandlerIfPossible(MethodCall $node): ?Node
+    private function refactorPageErrorHandlerIfPossible(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[0])) {
+        if (! isset($methodCall->args[0])) {
             return null;
         }
 
-        $code = $this->valueResolver->getValue($node->args[0]->value);
+        $code = $this->valueResolver->getValue($methodCall->args[0]->value);
 
         if (null === $code) {
             return null;
@@ -246,8 +246,8 @@ CODE_SAMPLE
         $message = null;
         if ('1' === (string) $code || is_bool($code) || 'true' === strtolower($code)) {
             $message = new String_('The page did not exist or was inaccessible.');
-            if (isset($node->args[2])) {
-                $reason = $node->args[2]->value;
+            if (isset($methodCall->args[2])) {
+                $reason = $methodCall->args[2]->value;
                 $message = $this->nodeFactory->createConcat([
                     $message,
                     new Ternary($reason, $this->nodeFactory->createConcat(
@@ -259,8 +259,8 @@ CODE_SAMPLE
 
         if ('' === $code) {
             $message = new String_('Page cannot be found.');
-            if (isset($node->args[2])) {
-                $reason = $node->args[2]->value;
+            if (isset($methodCall->args[2])) {
+                $reason = $methodCall->args[2]->value;
                 $message = new Ternary($reason, $this->nodeFactory->createConcat(
                     [new String_('Reason: '), $reason]
                 ), $message);

--- a/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
+++ b/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
@@ -53,7 +53,7 @@ final class PageNotFoundAndErrorHandlingRector extends AbstractRector
     ];
 
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v3/PropertyUserTsToMethodGetTsConfigOfBackendUserAuthenticationRector.php
+++ b/src/Rector/v9/v3/PropertyUserTsToMethodGetTsConfigOfBackendUserAuthenticationRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class PropertyUserTsToMethodGetTsConfigOfBackendUserAuthenticationRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v3/PropertyUserTsToMethodGetTsConfigOfBackendUserAuthenticationRector.php
+++ b/src/Rector/v9/v3/PropertyUserTsToMethodGetTsConfigOfBackendUserAuthenticationRector.php
@@ -69,14 +69,17 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
-        if ($this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals($node, Typo3NodeResolver::BACKEND_USER)) {
+        if ($this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals(
+            $propertyFetch,
+            Typo3NodeResolver::BACKEND_USER
+        )) {
             return false;
         }
 
         return ! $this->isObjectType(
-            $node->var,
+            $propertyFetch->var,
             new ObjectType('TYPO3\CMS\Core\Authentication\BackendUserAuthentication')
         );
     }

--- a/src/Rector/v9/v3/RefactorTsConfigRelatedMethodsRector.php
+++ b/src/Rector/v9/v3/RefactorTsConfigRelatedMethodsRector.php
@@ -32,7 +32,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RefactorTsConfigRelatedMethodsRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v3/UseMethodGetPageShortcutDirectlyFromSysPageRector.php
+++ b/src/Rector/v9/v3/UseMethodGetPageShortcutDirectlyFromSysPageRector.php
@@ -71,17 +71,17 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController')
         )) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isAnyMethodCallOnGlobals(
-            $node,
+            $methodCall,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         );
     }

--- a/src/Rector/v9/v3/UseMethodGetPageShortcutDirectlyFromSysPageRector.php
+++ b/src/Rector/v9/v3/UseMethodGetPageShortcutDirectlyFromSysPageRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseMethodGetPageShortcutDirectlyFromSysPageRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v3/ValidateAnnotationRector.php
+++ b/src/Rector/v9/v3/ValidateAnnotationRector.php
@@ -27,8 +27,8 @@ final class ValidateAnnotationRector extends AbstractRector
     private const OLD_ANNOTATION = 'validate';
 
     public function __construct(
-        private PhpDocTagRemover $phpDocTagRemover,
-        private ImportExtbaseAnnotationIfMissingFactory $importExtbaseAnnotationIfMissingFactory
+        private readonly PhpDocTagRemover $phpDocTagRemover,
+        private readonly ImportExtbaseAnnotationIfMissingFactory $importExtbaseAnnotationIfMissingFactory
     ) {
     }
 

--- a/src/Rector/v9/v4/AdditionalFieldProviderRector.php
+++ b/src/Rector/v9/v4/AdditionalFieldProviderRector.php
@@ -143,19 +143,19 @@ CODE_SAMPLE
         return new String_($methodCall);
     }
 
-    private function refactorMethodCall(MethodCall $node): ?Node
+    private function refactorMethodCall(MethodCall $methodCall): ?Node
     {
         if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Scheduler\Controller\SchedulerModuleController')
         )) {
             return null;
         }
 
-        if (! $this->isName($node->name, 'addMessage')) {
+        if (! $this->isName($methodCall->name, 'addMessage')) {
             return null;
         }
 
-        return $this->nodeFactory->createMethodCall('this', 'addMessage', $node->args);
+        return $this->nodeFactory->createMethodCall('this', 'addMessage', $methodCall->args);
     }
 }

--- a/src/Rector/v9/v4/RefactorDeprecatedConcatenateMethodsPageRendererRector.php
+++ b/src/Rector/v9/v4/RefactorDeprecatedConcatenateMethodsPageRendererRector.php
@@ -73,21 +73,23 @@ CODE_SAMPLE
         )]);
     }
 
-    private function createArrayMergeCall(MethodCall $node): FuncCall
+    private function createArrayMergeCall(MethodCall $methodCall): FuncCall
     {
-        $node1 = clone $node;
-        $node2 = clone $node;
+        $node1 = clone $methodCall;
+        $node2 = clone $methodCall;
         $node1->name = new Identifier('getConcatenateCss');
         $node2->name = new Identifier('getConcatenateJavascript');
         return $this->nodeFactory->createFuncCall('array_merge', [new Arg($node1), new Arg($node2)]);
     }
 
-    private function splitMethodCall(MethodCall $node, string $firstMethod, string $secondMethod): MethodCall
+    private function splitMethodCall(MethodCall $methodCall, string $firstMethod, string $secondMethod): MethodCall
     {
-        $node->name = new Identifier($firstMethod);
-        $node1 = clone $node;
+        $methodCall->name = new Identifier($firstMethod);
+
+        $node1 = clone $methodCall;
         $node1->name = new Identifier($secondMethod);
-        $this->nodesToAddCollector->addNodeAfterNode($node1, $node);
-        return $node;
+        $this->nodesToAddCollector->addNodeAfterNode($node1, $methodCall);
+
+        return $methodCall;
     }
 }

--- a/src/Rector/v9/v4/RemoveInitTemplateMethodCallRector.php
+++ b/src/Rector/v9/v4/RemoveInitTemplateMethodCallRector.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 final class RemoveInitTemplateMethodCallRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/RemoveMethodsFromEidUtilityAndTsfeRector.php
+++ b/src/Rector/v9/v4/RemoveMethodsFromEidUtilityAndTsfeRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveMethodsFromEidUtilityAndTsfeRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/RemoveMethodsFromEidUtilityAndTsfeRector.php
+++ b/src/Rector/v9/v4/RemoveMethodsFromEidUtilityAndTsfeRector.php
@@ -132,11 +132,11 @@ CODE_SAMPLE
         }
     }
 
-    private function delegateToFrontendUserProperty(MethodCall $node): MethodCall
+    private function delegateToFrontendUserProperty(MethodCall $methodCall): MethodCall
     {
         return $this->nodeFactory->createMethodCall(
-            $this->nodeFactory->createPropertyFetch($node->var, 'fe_user'),
-            (string) $this->getName($node->name)
+            $this->nodeFactory->createPropertyFetch($methodCall->var, 'fe_user'),
+            (string) $this->getName($methodCall->name)
         );
     }
 }

--- a/src/Rector/v9/v4/TemplateGetFileNameToFilePathSanitizerRector.php
+++ b/src/Rector/v9/v4/TemplateGetFileNameToFilePathSanitizerRector.php
@@ -30,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class TemplateGetFileNameToFilePathSanitizerRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/UseClassSchemaInsteadReflectionServiceMethodsRector.php
+++ b/src/Rector/v9/v4/UseClassSchemaInsteadReflectionServiceMethodsRector.php
@@ -179,127 +179,135 @@ CODE_SAMPLE
         return PhpVersionFeature::NULL_COALESCE;
     }
 
-    private function refactorGetPropertyTagsValuesMethod(MethodCall $node): ?Node
+    private function refactorGetPropertyTagsValuesMethod(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1])) {
+        if (! isset($methodCall->args[1])) {
             return null;
         }
 
         $propertyTagsValuesVariable = new Variable('propertyTagsValues');
         $propertyTagsValuesNode = new Expression(new Assign($propertyTagsValuesVariable, new Coalesce(
-            $this->createArrayDimFetchTags($node),
+            $this->createArrayDimFetchTags($methodCall),
             $this->nodeFactory->createArray([])
         )));
 
-        $this->nodesToAddCollector->addNodeBeforeNode($propertyTagsValuesNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($propertyTagsValuesNode, $methodCall);
 
         return $propertyTagsValuesVariable;
     }
 
-    private function refactorGetClassPropertyNamesMethod(MethodCall $node): Node
+    private function refactorGetClassPropertyNamesMethod(MethodCall $methodCall): Node
     {
         return $this->nodeFactory->createFuncCall(
             'array_keys',
-            [$this->nodeFactory->createMethodCall($this->createClassSchema($node), 'getProperties')]
+            [$this->nodeFactory->createMethodCall($this->createClassSchema($methodCall), 'getProperties')]
         );
     }
 
-    private function refactorGetPropertyTagValuesMethod(MethodCall $node): ?Node
+    private function refactorGetPropertyTagValuesMethod(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1])) {
+        if (! isset($methodCall->args[1])) {
             return null;
         }
 
-        if (! isset($node->args[2])) {
+        if (! isset($methodCall->args[2])) {
             return null;
         }
 
         return new Coalesce(
-            new ArrayDimFetch($this->createArrayDimFetchTags($node), $node->args[2]->value),
+            new ArrayDimFetch($this->createArrayDimFetchTags($methodCall), $methodCall->args[2]->value),
             $this->nodeFactory->createArray([])
         );
     }
 
-    private function createArrayDimFetchTags(MethodCall $node): ArrayDimFetch
+    private function createArrayDimFetchTags(MethodCall $methodCall): ArrayDimFetch
     {
         return new ArrayDimFetch(
             $this->nodeFactory->createMethodCall(
-                $this->createClassSchema($node),
+                $this->createClassSchema($methodCall),
                 'getProperty',
-                [$node->args[1]->value]
+                [$methodCall->args[1]->value]
             ),
             new String_(self::TAGS)
         );
     }
 
-    private function refactorGetClassTagsValues(MethodCall $node): MethodCall
+    private function refactorGetClassTagsValues(MethodCall $methodCall): MethodCall
     {
-        return $this->nodeFactory->createMethodCall($this->createClassSchema($node), 'getTags');
+        return $this->nodeFactory->createMethodCall($this->createClassSchema($methodCall), 'getTags');
     }
 
-    private function refactorGetClassTagValues(MethodCall $node): ?Node
+    private function refactorGetClassTagValues(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1])) {
+        if (! isset($methodCall->args[1])) {
             return null;
         }
 
         return new Coalesce(
-            new ArrayDimFetch($this->refactorGetClassTagsValues($node), $node->args[1]->value),
+            new ArrayDimFetch($this->refactorGetClassTagsValues($methodCall), $methodCall->args[1]->value),
             $this->nodeFactory->createArray([])
         );
     }
 
-    private function refactorGetMethodTagsValues(MethodCall $node): ?Node
+    private function refactorGetMethodTagsValues(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1])) {
+        if (! isset($methodCall->args[1])) {
             return null;
         }
 
         return new Coalesce(new ArrayDimFetch(
-            $this->nodeFactory->createMethodCall($this->createClassSchema($node), 'getMethod', [$node->args[1]->value]),
+            $this->nodeFactory->createMethodCall(
+                $this->createClassSchema($methodCall),
+                'getMethod',
+                [$methodCall->args[1]->value]
+            ),
             new String_(self::TAGS)
         ), $this->nodeFactory->createArray([]));
     }
 
-    private function refactorHasMethod(MethodCall $node): ?Node
+    private function refactorHasMethod(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1])) {
+        if (! isset($methodCall->args[1])) {
             return null;
         }
 
         return $this->nodeFactory->createMethodCall(
-            $this->createClassSchema($node),
+            $this->createClassSchema($methodCall),
             self::HAS_METHOD,
-            [$node->args[1]->value]
+            [$methodCall->args[1]->value]
         );
     }
 
-    private function refactorGetMethodParameters(MethodCall $node): ?Node
+    private function refactorGetMethodParameters(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1])) {
+        if (! isset($methodCall->args[1])) {
             return null;
         }
 
         return new Coalesce(new ArrayDimFetch(
-            $this->nodeFactory->createMethodCall($this->createClassSchema($node), 'getMethod', [$node->args[1]->value]),
+            $this->nodeFactory->createMethodCall(
+                $this->createClassSchema($methodCall),
+                'getMethod',
+                [$methodCall->args[1]->value]
+            ),
             new String_('params')
         ), $this->nodeFactory->createArray([]));
     }
 
-    private function refactorIsPropertyTaggedWith(MethodCall $node): ?Node
+    private function refactorIsPropertyTaggedWith(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1], $node->args[2])) {
+        if (! isset($methodCall->args[1], $methodCall->args[2])) {
             return null;
         }
 
         $propertyVariable = new Variable('propertyReflectionService');
         $propertyNode = new Expression(new Assign($propertyVariable, $this->nodeFactory->createMethodCall(
-            $this->nodeFactory->createMethodCall($node->var, 'getClassSchema', [$node->args[0]->value]),
+            $this->nodeFactory->createMethodCall($methodCall->var, 'getClassSchema', [$methodCall->args[0]->value]),
             'getProperty',
-            [$node->args[1]->value]
+            [$methodCall->args[1]->value]
         )));
 
-        $this->nodesToAddCollector->addNodeBeforeNode($propertyNode, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($propertyNode, $methodCall);
 
         return new Ternary(
             new Empty_($propertyVariable),
@@ -308,23 +316,26 @@ CODE_SAMPLE
                 [
                     new ArrayDimFetch(new ArrayDimFetch($propertyVariable, new String_(
                         self::TAGS
-                    )), $node->args[2]->value),
+                    )), $methodCall->args[2]->value),
                 ]
             )
         );
     }
 
-    private function refactorIsClassTaggedWith(MethodCall $node): ?Node
+    private function refactorIsClassTaggedWith(MethodCall $methodCall): ?Node
     {
-        if (! isset($node->args[1])) {
+        if (! isset($methodCall->args[1])) {
             return null;
         }
 
-        $tagValue = $node->args[1]->value;
+        $tagValue = $methodCall->args[1]->value;
         $closureUse = $tagValue instanceof Variable ? $tagValue : new Variable('tag');
         if (! $tagValue instanceof Variable) {
             $tempVarNode = new Expression(new Assign($closureUse, $tagValue));
-            $this->nodesToAddCollector->addNodeBeforeNode($tempVarNode, $node->getAttribute(AttributeKey::PARENT_NODE));
+            $this->nodesToAddCollector->addNodeBeforeNode(
+                $tempVarNode,
+                $methodCall->getAttribute(AttributeKey::PARENT_NODE)
+            );
         }
 
         $anonymousFunction = new Closure();
@@ -334,14 +345,14 @@ CODE_SAMPLE
 
         return new Bool_($this->nodeFactory->createFuncCall('count', [
             $this->nodeFactory->createFuncCall('array_filter', [
-                $this->nodeFactory->createFuncCall('array_keys', [$this->refactorGetClassTagsValues($node)]),
+                $this->nodeFactory->createFuncCall('array_keys', [$this->refactorGetClassTagsValues($methodCall)]),
                 $anonymousFunction,
             ]),
         ]));
     }
 
-    private function createClassSchema(MethodCall $node): MethodCall
+    private function createClassSchema(MethodCall $methodCall): MethodCall
     {
-        return $this->nodeFactory->createMethodCall($node->var, 'getClassSchema', [$node->args[0]->value]);
+        return $this->nodeFactory->createMethodCall($methodCall->var, 'getClassSchema', [$methodCall->args[0]->value]);
     }
 }

--- a/src/Rector/v9/v4/UseContextApiForVersioningWorkspaceIdRector.php
+++ b/src/Rector/v9/v4/UseContextApiForVersioningWorkspaceIdRector.php
@@ -89,21 +89,24 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
-        $node->var->setAttribute(AttributeKey::PHP_DOC_INFO, $node->getAttribute(AttributeKey::PHP_DOC_INFO));
+        $propertyFetch->var->setAttribute(
+            AttributeKey::PHP_DOC_INFO,
+            $propertyFetch->getAttribute(AttributeKey::PHP_DOC_INFO)
+        );
 
-        if ($this->isObjectType($node->var, new ObjectType('TYPO3\CMS\Frontend\Page\PageRepository'))) {
+        if ($this->isObjectType($propertyFetch->var, new ObjectType('TYPO3\CMS\Frontend\Page\PageRepository'))) {
             return false;
         }
 
         if ($this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals(
-            $node->var,
+            $propertyFetch->var,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         )) {
             return false;
         }
 
-        return ! $this->typo3NodeResolver->isPropertyFetchOnParentVariableOfTypePageRepository($node);
+        return ! $this->typo3NodeResolver->isPropertyFetchOnParentVariableOfTypePageRepository($propertyFetch);
     }
 }

--- a/src/Rector/v9/v4/UseContextApiForVersioningWorkspaceIdRector.php
+++ b/src/Rector/v9/v4/UseContextApiForVersioningWorkspaceIdRector.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Frontend\Page\PageRepository;
 final class UseContextApiForVersioningWorkspaceIdRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/UseContextApiRector.php
+++ b/src/Rector/v9/v4/UseContextApiRector.php
@@ -33,7 +33,7 @@ final class UseContextApiRector extends AbstractRector
     ];
 
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/UseContextApiRector.php
+++ b/src/Rector/v9/v4/UseContextApiRector.php
@@ -124,28 +124,28 @@ CODE_SAMPLE
         );
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
-        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parentNode = $propertyFetch->getAttribute(AttributeKey::PARENT_NODE);
 
         // Check if we have an assigment to the property, if so do not change it
         if ($parentNode instanceof Assign && $parentNode->var instanceof PropertyFetch) {
             return true;
         }
 
-        if (! $this->isNames($node->name, self::REFACTOR_PROPERTIES)) {
+        if (! $this->isNames($propertyFetch->name, self::REFACTOR_PROPERTIES)) {
             return true;
         }
 
         if ($this->isObjectType(
-            $node->var,
+            $propertyFetch->var,
             new ObjectType('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController')
         )) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals(
-            $node,
+            $propertyFetch,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         );
     }

--- a/src/Rector/v9/v4/UseGetMenuInsteadOfGetFirstWebPageRector.php
+++ b/src/Rector/v9/v4/UseGetMenuInsteadOfGetFirstWebPageRector.php
@@ -27,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseGetMenuInsteadOfGetFirstWebPageRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/UseGetMenuInsteadOfGetFirstWebPageRector.php
+++ b/src/Rector/v9/v4/UseGetMenuInsteadOfGetFirstWebPageRector.php
@@ -100,17 +100,17 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Frontend\Page\PageRepository')
         )) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isMethodCallOnPropertyOfGlobals(
-            $node,
+            $methodCall,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER,
             'sys_page'
         );

--- a/src/Rector/v9/v4/UseLanguageAspectForTsfeLanguagePropertiesRector.php
+++ b/src/Rector/v9/v4/UseLanguageAspectForTsfeLanguagePropertiesRector.php
@@ -102,22 +102,24 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(PropertyFetch $node): bool
+    private function shouldSkip(PropertyFetch $propertyFetch): bool
     {
         if ($this->isObjectType(
-            $node->var,
+            $propertyFetch->var,
             new ObjectType('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController')
         )) {
             return false;
         }
 
         if ($this->typo3NodeResolver->isPropertyFetchOnAnyPropertyOfGlobals(
-            $node,
+            $propertyFetch,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER
         )) {
             return false;
         }
 
-        return ! $this->typo3NodeResolver->isPropertyFetchOnParentVariableOfTypeTypoScriptFrontendController($node);
+        return ! $this->typo3NodeResolver->isPropertyFetchOnParentVariableOfTypeTypoScriptFrontendController(
+            $propertyFetch
+        );
     }
 }

--- a/src/Rector/v9/v4/UseLanguageAspectForTsfeLanguagePropertiesRector.php
+++ b/src/Rector/v9/v4/UseLanguageAspectForTsfeLanguagePropertiesRector.php
@@ -31,7 +31,7 @@ final class UseLanguageAspectForTsfeLanguagePropertiesRector extends AbstractRec
     ];
 
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/UseRootlineUtilityInsteadOfGetRootlineMethodRector.php
+++ b/src/Rector/v9/v4/UseRootlineUtilityInsteadOfGetRootlineMethodRector.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Frontend\Page\PageRepository;
 final class UseRootlineUtilityInsteadOfGetRootlineMethodRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v4/UseRootlineUtilityInsteadOfGetRootlineMethodRector.php
+++ b/src/Rector/v9/v4/UseRootlineUtilityInsteadOfGetRootlineMethodRector.php
@@ -79,22 +79,25 @@ CODE_SAMPLE
         ]);
     }
 
-    private function shouldSkip(MethodCall $node): bool
+    private function shouldSkip(MethodCall $methodCall): bool
     {
         if ($this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-            $node,
+            $methodCall,
             new ObjectType('TYPO3\CMS\Frontend\Page\PageRepository')
         )) {
             return false;
         }
 
-        $node->var->setAttribute(AttributeKey::PHP_DOC_INFO, $node->getAttribute(AttributeKey::PHP_DOC_INFO));
-        if ($this->isObjectType($node->var, new ObjectType('TYPO3\CMS\Frontend\Page\PageRepository'))) {
+        $methodCall->var->setAttribute(
+            AttributeKey::PHP_DOC_INFO,
+            $methodCall->getAttribute(AttributeKey::PHP_DOC_INFO)
+        );
+        if ($this->isObjectType($methodCall->var, new ObjectType('TYPO3\CMS\Frontend\Page\PageRepository'))) {
             return false;
         }
 
         return ! $this->typo3NodeResolver->isMethodCallOnPropertyOfGlobals(
-            $node,
+            $methodCall,
             Typo3NodeResolver::TYPO_SCRIPT_FRONTEND_CONTROLLER,
             'sys_page'
         );

--- a/src/Rector/v9/v4/UseSignalAfterExtensionInstallInsteadOfHasInstalledExtensionsRector.php
+++ b/src/Rector/v9/v4/UseSignalAfterExtensionInstallInsteadOfHasInstalledExtensionsRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseSignalAfterExtensionInstallInsteadOfHasInstalledExtensionsRector extends AbstractRector
 {
     public function __construct(
-        private ClassConstAnalyzer $classConstAnalyzer
+        private readonly ClassConstAnalyzer $classConstAnalyzer
     ) {
     }
 

--- a/src/Rector/v9/v4/UseSignalTablesDefinitionIsBeingBuiltSqlExpectedSchemaServiceRector.php
+++ b/src/Rector/v9/v4/UseSignalTablesDefinitionIsBeingBuiltSqlExpectedSchemaServiceRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UseSignalTablesDefinitionIsBeingBuiltSqlExpectedSchemaServiceRector extends AbstractRector
 {
     public function __construct(
-        private ClassConstAnalyzer $classConstAnalyzer
+        private readonly ClassConstAnalyzer $classConstAnalyzer
     ) {
     }
 

--- a/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommand/AddArgumentToSymfonyCommandRector.php
+++ b/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommand/AddArgumentToSymfonyCommandRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
         $this->commandInputArguments = $commandInputArguments;
     }
 
-    private function addArgumentsToConfigureMethod(ClassMethod $node): ClassMethod
+    private function addArgumentsToConfigureMethod(ClassMethod $classMethod): ClassMethod
     {
         foreach ($this->commandInputArguments as $commandInputArgument) {
             $mode = $this->createMode((int) $commandInputArgument['mode']);
@@ -126,20 +126,20 @@ CODE_SAMPLE
             $name = new String_($commandInputArgument[self::NAME]);
             $description = new String_($commandInputArgument['description']);
             $defaultValue = $commandInputArgument['default'];
-            $node->stmts[] = new Expression($this->nodeFactory->createMethodCall(
+            $classMethod->stmts[] = new Expression($this->nodeFactory->createMethodCall(
                 'this',
                 'addArgument',
                 [$name, $mode, $description, $defaultValue]
             ));
         }
 
-        return $node;
+        return $classMethod;
     }
 
-    private function addArgumentsToExecuteMethod(ClassMethod $node): ClassMethod
+    private function addArgumentsToExecuteMethod(ClassMethod $classMethod): ClassMethod
     {
-        if (null === $node->stmts) {
-            return $node;
+        if (null === $classMethod->stmts) {
+            return $classMethod;
         }
 
         $argumentStatements = [];
@@ -153,9 +153,9 @@ CODE_SAMPLE
             $argumentStatements[] = new Expression($assignment);
         }
 
-        array_unshift($node->stmts, ...$argumentStatements);
+        array_unshift($classMethod->stmts, ...$argumentStatements);
 
-        return $node;
+        return $classMethod;
     }
 
     private function createMode(int $mode): ClassConstFetch

--- a/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommandRector.php
+++ b/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommandRector.php
@@ -42,15 +42,15 @@ final class ExtbaseCommandControllerToSymfonyCommandRector extends AbstractRecto
     private const REMOVE_EMPTY_LINES = '/^[ \t]*[\r\n]+/m';
 
     public function __construct(
-        private SmartFileSystem $smartFileSystem,
-        private RectorParser $rectorParser,
-        private AddArgumentToSymfonyCommandRector $addArgumentToSymfonyCommandRector,
-        private FilesFinder $filesFinder,
-        private AddCommandsToReturnRector $addCommandsToReturnRector,
-        private SimplePhpParser $simplePhpParser,
-        private TemplateFinder $templateFinder,
-        private NodePrinterInterface $nodePrinter,
-        private RemovedAndAddedFilesCollector $removedAndAddedFilesCollector
+        private readonly SmartFileSystem $smartFileSystem,
+        private readonly RectorParser $rectorParser,
+        private readonly AddArgumentToSymfonyCommandRector $addArgumentToSymfonyCommandRector,
+        private readonly FilesFinder $filesFinder,
+        private readonly AddCommandsToReturnRector $addCommandsToReturnRector,
+        private readonly SimplePhpParser $simplePhpParser,
+        private readonly TemplateFinder $templateFinder,
+        private readonly NodePrinterInterface $nodePrinter,
+        private readonly RemovedAndAddedFilesCollector $removedAndAddedFilesCollector
     ) {
     }
 

--- a/src/Rector/v9/v5/RefactorProcessOutputRector.php
+++ b/src/Rector/v9/v5/RefactorProcessOutputRector.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 final class RefactorProcessOutputRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v5/RefactorProcessOutputRector.php
+++ b/src/Rector/v9/v5/RefactorProcessOutputRector.php
@@ -97,15 +97,15 @@ CODE_SAMPLE
         );
     }
 
-    private function refactorToNewMethodCalls(MethodCall $node): void
+    private function refactorToNewMethodCalls(MethodCall $methodCall): void
     {
-        $node->name = new Identifier('applyHttpHeadersToResponse');
+        $methodCall->name = new Identifier('applyHttpHeadersToResponse');
 
         $response = new New_(new FullyQualified('TYPO3\CMS\Core\Http\Response'));
 
-        $node->args[0] = $this->nodeFactory->createArg($response);
+        $methodCall->args[0] = $this->nodeFactory->createArg($response);
 
-        $newNode = $this->nodeFactory->createMethodCall($node->var, 'processContentForOutput');
-        $this->nodesToAddCollector->addNodeAfterNode($newNode, $node);
+        $newNode = $this->nodeFactory->createMethodCall($methodCall->var, 'processContentForOutput');
+        $this->nodesToAddCollector->addNodeAfterNode($newNode, $methodCall);
     }
 }

--- a/src/Rector/v9/v5/RefactorPropertiesOfTypoScriptFrontendControllerRector.php
+++ b/src/Rector/v9/v5/RefactorPropertiesOfTypoScriptFrontendControllerRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RefactorPropertiesOfTypoScriptFrontendControllerRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Rector/v9/v5/RefactorTypeInternalTypeFileAndFileReferenceToFalRector.php
+++ b/src/Rector/v9/v5/RefactorTypeInternalTypeFileAndFileReferenceToFalRector.php
@@ -28,7 +28,7 @@ final class RefactorTypeInternalTypeFileAndFileReferenceToFalRector extends Abst
     private const MESSAGE = 'You have to migrate the legacy file field to FAL';
 
     public function __construct(
-        private RectorOutputStyle $rectorOutputStyle
+        private readonly RectorOutputStyle $rectorOutputStyle
     ) {
     }
 

--- a/src/Rector/v9/v5/RemoveFlushCachesRector.php
+++ b/src/Rector/v9/v5/RemoveFlushCachesRector.php
@@ -18,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveFlushCachesRector extends AbstractRector
 {
     public function __construct(
-        private PhpDocTagRemover $phpDocTagRemover
+        private readonly PhpDocTagRemover $phpDocTagRemover
     ) {
     }
 

--- a/src/Rector/v9/v5/RemoveInternalAnnotationRector.php
+++ b/src/Rector/v9/v5/RemoveInternalAnnotationRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveInternalAnnotationRector extends AbstractRector
 {
     public function __construct(
-        private PhpDocTagRemover $phpDocTagRemover
+        private readonly PhpDocTagRemover $phpDocTagRemover
     ) {
     }
 

--- a/src/Rector/v9/v5/UsePackageManagerActivePackagesRector.php
+++ b/src/Rector/v9/v5/UsePackageManagerActivePackagesRector.php
@@ -18,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UsePackageManagerActivePackagesRector extends AbstractRector
 {
     public function __construct(
-        private Typo3NodeResolver $typo3NodeResolver
+        private readonly Typo3NodeResolver $typo3NodeResolver
     ) {
     }
 

--- a/src/Template/TemplateFinder.php
+++ b/src/Template/TemplateFinder.php
@@ -8,7 +8,7 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class TemplateFinder
 {
-    private string $templateDirectory;
+    private readonly string $templateDirectory;
 
     public function __construct()
     {

--- a/utils/composer-packages/src/Command/AddComposerTypo3ExtensionsToConfigCommand.php
+++ b/utils/composer-packages/src/Command/AddComposerTypo3ExtensionsToConfigCommand.php
@@ -30,14 +30,14 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 final class AddComposerTypo3ExtensionsToConfigCommand extends Command
 {
     public function __construct(
-        private PackageResolver $packageResolver,
-        private RectorParser $rectorParser,
-        private ComposerConfigurationPathResolver $composerConfigurationPathResolver,
-        private SmartFileSystem $smartFileSystem,
-        private BetterStandardPrinter $betterStandardPrinter,
-        private AddPackageVersionRector $addPackageVersionRector,
-        private AddReplacePackageRector $replacePackageRector,
-        private CurrentFileProvider $currentFileProvider
+        private readonly PackageResolver $packageResolver,
+        private readonly RectorParser $rectorParser,
+        private readonly ComposerConfigurationPathResolver $composerConfigurationPathResolver,
+        private readonly SmartFileSystem $smartFileSystem,
+        private readonly BetterStandardPrinter $betterStandardPrinter,
+        private readonly AddPackageVersionRector $addPackageVersionRector,
+        private readonly AddReplacePackageRector $replacePackageRector,
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
         parent::__construct();
     }

--- a/utils/composer-packages/src/NodeAnalyzer/SymfonyPhpConfigClosureAnalyzer.php
+++ b/utils/composer-packages/src/NodeAnalyzer/SymfonyPhpConfigClosureAnalyzer.php
@@ -11,7 +11,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 final class SymfonyPhpConfigClosureAnalyzer
 {
     public function __construct(
-        private NodeNameResolver $nodeNameResolver
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/utils/composer-packages/src/PackagistPackageResolver.php
+++ b/utils/composer-packages/src/PackagistPackageResolver.php
@@ -11,7 +11,7 @@ use UnexpectedValueException;
 final class PackagistPackageResolver implements PackageResolver
 {
     public function __construct(
-        private PackageParser $packageParser
+        private readonly PackageParser $packageParser
     ) {
     }
 

--- a/utils/composer-packages/src/Rector/AddPackageVersionRector.php
+++ b/utils/composer-packages/src/Rector/AddPackageVersionRector.php
@@ -26,7 +26,7 @@ final class AddPackageVersionRector extends AbstractRector
     private ?ExtensionVersion $extensionVersion = null;
 
     public function __construct(
-        private SymfonyPhpConfigClosureAnalyzer $symfonyPhpConfigClosureAnalyzer
+        private readonly SymfonyPhpConfigClosureAnalyzer $symfonyPhpConfigClosureAnalyzer
     ) {
     }
 

--- a/utils/composer-packages/src/Rector/AddReplacePackageRector.php
+++ b/utils/composer-packages/src/Rector/AddReplacePackageRector.php
@@ -31,7 +31,7 @@ final class AddReplacePackageRector extends AbstractRector implements Configurab
     private ?array $renamePackages = null;
 
     public function __construct(
-        private SymfonyPhpConfigClosureAnalyzer $symfonyPhpConfigClosureAnalyzer
+        private readonly SymfonyPhpConfigClosureAnalyzer $symfonyPhpConfigClosureAnalyzer
     ) {
     }
 

--- a/utils/composer-packages/src/Rector/RemovePackageVersionsRector.php
+++ b/utils/composer-packages/src/Rector/RemovePackageVersionsRector.php
@@ -20,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemovePackageVersionsRector extends AbstractRector
 {
     public function __construct(
-        private SymfonyPhpConfigClosureAnalyzer $symfonyPhpConfigClosureAnalyzer
+        private readonly SymfonyPhpConfigClosureAnalyzer $symfonyPhpConfigClosureAnalyzer
     ) {
     }
 

--- a/utils/composer-packages/src/ValueObject/ComposerPackage.php
+++ b/utils/composer-packages/src/ValueObject/ComposerPackage.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\Assert;
 
 final class ComposerPackage implements Stringable
 {
-    private string $package;
+    private readonly string $package;
 
     public function __construct(string $package)
     {

--- a/utils/composer-packages/src/ValueObject/ExtensionVersion.php
+++ b/utils/composer-packages/src/ValueObject/ExtensionVersion.php
@@ -21,9 +21,9 @@ final class ExtensionVersion implements Stringable
      * @param Typo3Version[] $typo3Versions
      */
     public function __construct(
-        private PackageAndVersion $packageAndVersion,
+        private readonly PackageAndVersion $packageAndVersion,
         array $typo3Versions,
-        private ?RenamePackage $replacePackage = null
+        private readonly ?RenamePackage $replacePackage = null
     ) {
         Assert::allIsInstanceOf($typo3Versions, Typo3Version::class);
         $this->typo3Versions = $typo3Versions;

--- a/utils/composer-packages/src/ValueObject/Typo3Version.php
+++ b/utils/composer-packages/src/ValueObject/Typo3Version.php
@@ -9,7 +9,7 @@ use Stringable;
 final class Typo3Version implements Stringable
 {
     public function __construct(
-        private string $version
+        private readonly string $version
     ) {
     }
 

--- a/utils/generator/src/Command/Typo3GenerateCommand.php
+++ b/utils/generator/src/Command/Typo3GenerateCommand.php
@@ -30,10 +30,10 @@ final class Typo3GenerateCommand extends Command
     public const RECTOR_FQN_NAME_PATTERN = 'Ssch\TYPO3Rector\Rector\__Major__\__Minor__\__Name__';
 
     public function __construct(
-        private TemplateFinder $templateFinder,
-        private FileGenerator $fileGenerator,
-        private RectorOutputStyle $rectorOutputStyle,
-        private ConfigFilesystem $configFilesystem
+        private readonly TemplateFinder $templateFinder,
+        private readonly FileGenerator $fileGenerator,
+        private readonly RectorOutputStyle $rectorOutputStyle,
+        private readonly ConfigFilesystem $configFilesystem
     ) {
         parent::__construct();
     }

--- a/utils/generator/src/Generator/FileGenerator.php
+++ b/utils/generator/src/Generator/FileGenerator.php
@@ -12,9 +12,9 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 final class FileGenerator
 {
     public function __construct(
-        private SmartFileSystem $smartFileSystem,
-        private TemplateFactory $templateFactory,
-        private TemplateFileSystem $templateFileSystem
+        private readonly SmartFileSystem $smartFileSystem,
+        private readonly TemplateFactory $templateFactory,
+        private readonly TemplateFileSystem $templateFileSystem
     ) {
     }
 

--- a/utils/generator/src/ValueObject/Description.php
+++ b/utils/generator/src/ValueObject/Description.php
@@ -8,7 +8,7 @@ use Webmozart\Assert\Assert;
 
 final class Description
 {
-    private string $description;
+    private readonly string $description;
 
     private function __construct(string $description)
     {

--- a/utils/generator/src/ValueObject/Name.php
+++ b/utils/generator/src/ValueObject/Name.php
@@ -8,7 +8,7 @@ use Webmozart\Assert\Assert;
 
 final class Name
 {
-    private string $name;
+    private readonly string $name;
 
     private function __construct(string $name)
     {

--- a/utils/generator/src/ValueObject/Typo3RectorRecipe.php
+++ b/utils/generator/src/ValueObject/Typo3RectorRecipe.php
@@ -7,10 +7,10 @@ namespace Ssch\TYPO3Rector\Generator\ValueObject;
 final class Typo3RectorRecipe
 {
     public function __construct(
-        private Typo3Version $typo3Version,
-        private Url $url,
-        private Name $name,
-        private Description $description
+        private readonly Typo3Version $typo3Version,
+        private readonly Url $url,
+        private readonly Name $name,
+        private readonly Description $description
     ) {
     }
 

--- a/utils/generator/src/ValueObject/Typo3Version.php
+++ b/utils/generator/src/ValueObject/Typo3Version.php
@@ -9,8 +9,8 @@ use Webmozart\Assert\Assert;
 final class Typo3Version
 {
     private function __construct(
-        private int $major,
-        private int $minor
+        private readonly int $major,
+        private readonly int $minor
     ) {
     }
 

--- a/utils/generator/src/ValueObject/Url.php
+++ b/utils/generator/src/ValueObject/Url.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 final class Url
 {
-    private string $url;
+    private readonly string $url;
 
     private function __construct(string $url)
     {

--- a/utils/phpstan/src/Rules/AddChangelogDocBlockForRectorClassRule.php
+++ b/utils/phpstan/src/Rules/AddChangelogDocBlockForRectorClassRule.php
@@ -45,8 +45,8 @@ final class AddChangelogDocBlockForRectorClassRule implements Rule
     ];
 
     public function __construct(
-        private Broker $broker,
-        private FileTypeMapper $fileTypeMapper
+        private readonly Broker $broker,
+        private readonly FileTypeMapper $fileTypeMapper
     ) {
     }
 

--- a/utils/phpstan/src/Rules/AddCodeCoverageIgnoreForRectorDefinitionRule.php
+++ b/utils/phpstan/src/Rules/AddCodeCoverageIgnoreForRectorDefinitionRule.php
@@ -26,7 +26,7 @@ final class AddCodeCoverageIgnoreForRectorDefinitionRule implements Rule
     public const ERROR_MESSAGE = 'Provide @codeCoverageIgnore doc block for "%s" RectorDefinition method';
 
     public function __construct(
-        private FileTypeMapper $fileTypeMapper
+        private readonly FileTypeMapper $fileTypeMapper
     ) {
     }
 

--- a/utils/phpstan/src/Type/ObjectManagerDynamicReturnTypeExtension.php
+++ b/utils/phpstan/src/Type/ObjectManagerDynamicReturnTypeExtension.php
@@ -14,7 +14,7 @@ use Ssch\TYPO3Rector\PHPStan\TypeResolver\ArgumentTypeResolver;
 final class ObjectManagerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
     public function __construct(
-        private ArgumentTypeResolver $argumentTypeResolver
+        private readonly ArgumentTypeResolver $argumentTypeResolver
     ) {
     }
 

--- a/utils/phpstan/src/Type/ValidatorResolverDynamicReturnTypeExtension.php
+++ b/utils/phpstan/src/Type/ValidatorResolverDynamicReturnTypeExtension.php
@@ -14,7 +14,7 @@ use Ssch\TYPO3Rector\PHPStan\TypeResolver\ArgumentTypeResolver;
 final class ValidatorResolverDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
     public function __construct(
-        private ArgumentTypeResolver $argumentTypeResolver
+        private readonly ArgumentTypeResolver $argumentTypeResolver
     ) {
     }
 


### PR DESCRIPTION
I've noticed some variables have known type, but are refered further in the code as `$node`. That makes the code reading very confusing, as `$node` could be anything. If we know the type is e.g. `MethodCall`, the node should be named `$methodCall`, so we can know by reading the name what methods can we use :+1: 

This will help us with adding "naming" set to avoid manual work on type=variable name matching.