### PR TITLE
[DX] Remove dependency on NodesToReplaceCollector, return nodes directly in transparent way instead

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -115,3 +115,8 @@ parameters:
         -
             message: "#^Value object \"RenamePackage\" should be named \"AddReplacePackage\" instead to respect used service$#"
             path: utils/composer-packages/tests/Rector/AddReplacePackageRector/config/configured_rule.php
+
+        # phpstan lost ability to analyze properties
+        -
+            message: '#Strict comparison using \!\=\= between array\{\} and array\{\} will always evaluate to false#'
+            path: src/Rector/v8/v6/MigrateOptionsOfTypeGroupRector.php

--- a/src/Rector/Migrations/RenameClassMapAliasRector.php
+++ b/src/Rector/Migrations/RenameClassMapAliasRector.php
@@ -123,7 +123,7 @@ CODE_SAMPLE
             return $this->stringClassNameToClassConstantRectorIfPossible($node);
         }
 
-        return $this->classRenamer->renameNode($node, $this->oldToNewClasses, $this->file);
+        return $this->classRenamer->renameNode($node, $this->oldToNewClasses);
     }
 
     /**

--- a/src/Rector/v10/v4/UseIconsFromSubFolderInIconRegistryRector.php
+++ b/src/Rector/v10/v4/UseIconsFromSubFolderInIconRegistryRector.php
@@ -61,12 +61,13 @@ final class UseIconsFromSubFolderInIconRegistryRector extends AbstractRector
             return null;
         }
 
-        if (! str_starts_with($options[self::SOURCE], 'typo3/sysext/core/Resources/Public/Icons/T3Icons/content/')) {
+        $source = (string) $options[self::SOURCE];
+        if (! str_starts_with($source, 'typo3/sysext/core/Resources/Public/Icons/T3Icons/content/')) {
             return null;
         }
 
         $options[self::SOURCE] = Strings::replace(
-            $options[self::SOURCE],
+            $source,
             '#typo3/sysext/core/Resources/Public/Icons/T3Icons/content/#i',
             'typo3/sysext/core/Resources/Public/Icons/T3Icons/svgs/content/'
         );

--- a/src/Rector/v11/v5/SubstituteBackendTemplateViewWithModuleTemplateRector.php
+++ b/src/Rector/v11/v5/SubstituteBackendTemplateViewWithModuleTemplateRector.php
@@ -208,7 +208,7 @@ CODE_SAMPLE
             return new Variable(self::MODULE_TEMPLATE);
         });
 
-        if (false === $hasChanged) {
+        if (! $hasChanged) {
             return;
         }
 

--- a/src/Rector/v11/v5/SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector.php
+++ b/src/Rector/v11/v5/SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector.php
@@ -69,7 +69,6 @@ final class SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector e
             }
         }
 
-        // change the node
         return $node;
     }
 
@@ -169,13 +168,12 @@ CODE_SAMPLE
 
     private function addPageRendererToConstructor(Class_ $class): void
     {
-        $this->classDependencyManipulator->addConstructorDependency(
-            $class,
-            new PropertyMetadata(
-                'pageRenderer',
-                new ObjectType('TYPO3\CMS\Core\Page\PageRenderer'),
-                Class_::MODIFIER_PRIVATE
-            )
+        $propertyMetadata = new PropertyMetadata(
+            'pageRenderer',
+            new ObjectType('TYPO3\CMS\Core\Page\PageRenderer'),
+            Class_::MODIFIER_PRIVATE
         );
+
+        $this->classDependencyManipulator->addConstructorDependency($class, $propertyMetadata);
     }
 }

--- a/src/Rector/v8/v5/MoveLanguageFilesFromLocallangToResourcesRector.php
+++ b/src/Rector/v8/v5/MoveLanguageFilesFromLocallangToResourcesRector.php
@@ -75,10 +75,10 @@ final class MoveLanguageFilesFromLocallangToResourcesRector extends AbstractRect
      */
     public function refactor(Node $node): ?Node
     {
-        $value = $this->valueResolver->getValue($node);
+        $value = $node->value;
 
         foreach (self::MAPPING_OLD_TO_NEW_PATHS as $oldPath => $newPath) {
-            if (\str_contains((string) $value, $oldPath)) {
+            if (\str_contains($value, $oldPath)) {
                 return new String_(str_replace($oldPath, $newPath, $value));
             }
         }

--- a/src/Rector/v8/v6/MoveRequestUpdateOptionFromControlToColumnsRector.php
+++ b/src/Rector/v8/v6/MoveRequestUpdateOptionFromControlToColumnsRector.php
@@ -142,7 +142,6 @@ CODE_SAMPLE
             $columnItem->value->items[] = new ArrayItem(new String_('reload'), new String_('onChange'));
         }
 
-        // change the node
         return $node;
     }
 }

--- a/src/Rector/v8/v6/MoveTypeGroupSuggestWizardToSuggestOptionsRector.php
+++ b/src/Rector/v8/v6/MoveTypeGroupSuggestWizardToSuggestOptionsRector.php
@@ -213,7 +213,12 @@ CODE_SAMPLE
                     continue;
                 }
 
-                if (! \str_starts_with($this->valueResolver->getValue($item->key), '_')) {
+                $keyValue = $this->valueResolver->getValue($item->key);
+                if (! is_string($keyValue)) {
+                    continue;
+                }
+
+                if (! \str_starts_with($keyValue, '_')) {
                     $nodeEmpty = false;
                     break;
                 }

--- a/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
+++ b/src/Rector/v9/v2/PageNotFoundAndErrorHandlingRector.php
@@ -244,7 +244,7 @@ CODE_SAMPLE
         }
 
         $message = null;
-        if ('1' === (string) $code || is_bool($code) || 'true' === strtolower($code)) {
+        if ('1' === (string) $code || is_bool($code) || 'true' === strtolower((string) $code)) {
             $message = new String_('The page did not exist or was inaccessible.');
             if (isset($methodCall->args[2])) {
                 $reason = $methodCall->args[2]->value;

--- a/src/Rector/v9/v3/MoveLanguageFilesFromExtensionLangRector.php
+++ b/src/Rector/v9/v3/MoveLanguageFilesFromExtensionLangRector.php
@@ -49,8 +49,7 @@ final class MoveLanguageFilesFromExtensionLangRector extends AbstractRector
     public function refactor(Node $node): ?Node
     {
         $value = $this->valueResolver->getValue($node);
-
-        if (null === $value || ! is_string($value)) {
+        if (! is_string($value)) {
             return null;
         }
 

--- a/src/Rector/v9/v3/ValidateAnnotationRector.php
+++ b/src/Rector/v9/v3/ValidateAnnotationRector.php
@@ -134,7 +134,12 @@ CODE_SAMPLE
 
             $optionsArray = [];
             foreach ($optionNames as $key => $optionName) {
-                $optionValue = str_replace("'", '"', $optionValues[$key]);
+                $optionValue = $optionValues[$key];
+                if (! is_string($optionValue)) {
+                    continue;
+                }
+
+                $optionValue = str_replace("'", '"', $optionValue);
                 $optionsArray[] = sprintf('"%s": %s', trim($optionName), trim($optionValue));
             }
 

--- a/utils/composer-packages/src/ComposerPackageParser.php
+++ b/utils/composer-packages/src/ComposerPackageParser.php
@@ -74,7 +74,7 @@ final class ComposerPackageParser implements PackageParser
             $replacePackage = null;
             if (array_key_exists(self::REPLACE, $package) && is_array($package[self::REPLACE])) {
                 foreach (array_keys($package[self::REPLACE]) as $replace) {
-                    if (\str_starts_with($replace, 'typo3-ter')) {
+                    if (\str_starts_with((string) $replace, 'typo3-ter')) {
                         $replacePackage = new RenamePackage($replace, (string) $composerPackage);
                         break;
                     }


### PR DESCRIPTION
I've noticed we have a hacky services in Rector, that can be now solved in much cleaner way directly in the rule.

There are just 4 places that use it, 3 of them here. Let's clean :soap:  :) 
