### PR TITLE
[DX] Remove TypoScriptFileProcessor dependency on editorconfig, rather use the current file spacing setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^9.5",
         "rector/phpstan-rules": "^0.5",
         "rector/rector-generator": "dev-main",
-        "rector/rector-src": "dev-main#ffd84e6",
+        "rector/rector-src": "dev-main#cb07c30",
         "symfony/console": "^6.0",
         "symplify/coding-standard": "^10.2",
         "symplify/easy-coding-standard": "^10.2",


### PR DESCRIPTION
I'm cleaning Rector from a code-formatting, to make it less widespread :) and better focused on refactoring itself

Ref https://github.com/rectorphp/rector-src/pull/2378