### PR TITLE
[composer] remove php-cs-fixer, already in ECS, fix newer php-parser for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ composer.lock
 php-scoper.phar
 typo3-rector-scoped
 tests/FileProcessor/TypoScript/Configuration_Extbase_Persistence_Classes.php
+
+preload.php

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "symfony/string": "^6.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.8",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,7 +31,7 @@ parameters:
         disableRuntimeReflectionProvider: true
 
     bootstrapFiles:
-         - tests/bootstrap.php
+         - tests/bootstrap-phpstan.php
 
     inferPrivatePropertyTypeFromConstructor: true
     reportUnmatchedIgnoredErrors: false

--- a/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommandRector.php
+++ b/src/Rector/v9/v5/ExtbaseCommandControllerToSymfonyCommandRector.php
@@ -7,6 +7,7 @@ namespace Ssch\TYPO3Rector\Rector\v9\v5;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
@@ -72,6 +73,10 @@ final class ExtbaseCommandControllerToSymfonyCommandRector extends AbstractRecto
 
         $commandClassMethods = $this->findCommandMethods($node);
         if ([] === $commandClassMethods) {
+            return null;
+        }
+
+        if (! $node->namespacedName instanceof Name) {
             return null;
         }
 

--- a/tests/bootstrap-phpstan.php
+++ b/tests/bootstrap-phpstan.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Tracy\Debugger;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+include_once __DIR__ . '/../typo3.constants.php';
+// silent deprecations, since we test them
+error_reporting(E_ALL & ~E_NOTICE | E_DEPRECATED);
+// performance boost
+gc_disable();
+// define some globals
+
+$GLOBALS['TYPO3_LOADED_EXT'] = [];
+$GLOBALS['PARSETIME_START'] = time();
+$GLOBALS['TYPO3_MISC']['microtime_start'] = microtime();
+$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'] = 'jpg, gif';
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = 'dbname';
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = 'user';
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = 'password';
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = 'host';
+$GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern'] = '\\.(php[3-8]?|phpsh|phtml|pht|phar|shtml|cgi)(\\..*)?$|\\.pl$|^\\.htaccess$';
+$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['foo'] = 'a:6:{s:9:"loginLogo";s:8:"logo.jpg";s:19:"loginHighlightColor";s:7:"#000000";s:20:"loginBackgroundImage";s:8:"logo.jpg";s:13:"loginFootnote";s:8:"Footnote";s:11:"backendLogo";s:0:"";s:14:"backendFavicon";s:0:"";}';
+// for dump() function
+Debugger::$maxDepth = 2;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,28 +2,8 @@
 
 declare(strict_types=1);
 
-use Tracy\Debugger;
+require_once __DIR__ . '/bootstrap-phpstan.php';
 
-require_once __DIR__ . '/../vendor/autoload.php';
-include_once __DIR__ . '/../typo3.constants.php';
-// silent deprecations, since we test them
-error_reporting(E_ALL & ~E_NOTICE | E_DEPRECATED);
-// performance boost
-gc_disable();
-// define some globals
-
-$GLOBALS['TYPO3_LOADED_EXT'] = [];
-$GLOBALS['PARSETIME_START'] = time();
-$GLOBALS['TYPO3_MISC']['microtime_start'] = microtime();
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'] = 'jpg, gif';
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = 'dbname';
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = 'user';
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = 'password';
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = 'host';
-$GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern'] = '\\.(php[3-8]?|phpsh|phtml|pht|phar|shtml|cgi)(\\..*)?$|\\.pl$|^\\.htaccess$';
-$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['foo'] = 'a:6:{s:9:"loginLogo";s:8:"logo.jpg";s:19:"loginHighlightColor";s:7:"#000000";s:20:"loginBackgroundImage";s:8:"logo.jpg";s:13:"loginFootnote";s:8:"Footnote";s:11:"backendLogo";s:0:"";s:14:"backendFavicon";s:0:"";}';
-// for dump() function
-Debugger::$maxDepth = 2;
 
 
 // autoload rector php-parser first with local paths

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,3 +24,12 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern'] = '\\.(php[3-8]?|phpsh|phtm
 $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['foo'] = 'a:6:{s:9:"loginLogo";s:8:"logo.jpg";s:19:"loginHighlightColor";s:7:"#000000";s:20:"loginBackgroundImage";s:8:"logo.jpg";s:13:"loginFootnote";s:8:"Footnote";s:11:"backendLogo";s:0:"";s:14:"backendFavicon";s:0:"";}';
 // for dump() function
 Debugger::$maxDepth = 2;
+
+
+// autoload rector php-parser first with local paths
+// build preload file to autoload local php-parser instead of phpstan one, e.g. in case of early upgrade
+exec('php vendor/rector/rector-src/build/build-preload.php .');
+sleep(1);
+
+require __DIR__ . '/../preload.php';
+unlink(__DIR__ . '/../preload.php');


### PR DESCRIPTION
Native php-parser is loaded from phpstan, which is now older version 4.14.
To test php-parser 5.0-dev, we need to preload if from local vendor.

See https://github.com/rectorphp/rector-src/pull/2437