### PR TITLE
[BUGFIX] enable parsing custom tags in yaml

### DIFF
--- a/src/FileProcessor/Yaml/Form/FormYamlFileProcessor.php
+++ b/src/FileProcessor/Yaml/Form/FormYamlFileProcessor.php
@@ -73,7 +73,7 @@ final class FormYamlFileProcessor implements FileProcessorInterface
 
         $smartFileInfo = $file->getSmartFileInfo();
         $oldYamlContent = $smartFileInfo->getContents();
-        $yaml = Yaml::parse($oldYamlContent);
+        $yaml = Yaml::parse($oldYamlContent, Yaml::PARSE_CUSTOM_TAGS);
 
         if (! is_array($yaml)) {
             return $systemErrorsAndFileDiffs;


### PR DESCRIPTION
this PR resolves the Issue 'Tags support is not enabled. Enable the "Yaml::PARSE_CUSTOM_TAGS"' when using custom tags in yaml.