### PR TITLE
[FEATURE] Provide rules to migrate EXT:vhs viewhelpers

### DIFF
--- a/config/replace-vhs.php
+++ b/config/replace-vhs.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceExtensionPathRelativeFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceFormatJsonEncodeFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceLFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceMediaImageFluidRector;
@@ -12,6 +13,7 @@ use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceVariableSetFluidRecto
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/config.php');
+    $rectorConfig->rule(ReplaceExtensionPathRelativeFluidRector::class);
     $rectorConfig->rule(ReplaceFormatJsonEncodeFluidRector::class);
     $rectorConfig->rule(ReplaceLFluidRector::class);
     $rectorConfig->rule(ReplaceMediaImageFluidRector::class);

--- a/config/replace-vhs.php
+++ b/config/replace-vhs.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceFormatJsonEncodeFluidRector;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceLFluidRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/config.php');
     $rectorConfig->rule(ReplaceFormatJsonEncodeFluidRector::class);
+    $rectorConfig->rule(ReplaceLFluidRector::class);
 };

--- a/config/replace-vhs.php
+++ b/config/replace-vhs.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceFormatJsonEncodeFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceLFluidRector;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceMediaImageFluidRector;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceUriImageFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceVariableSetFluidRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/config.php');
     $rectorConfig->rule(ReplaceFormatJsonEncodeFluidRector::class);
     $rectorConfig->rule(ReplaceLFluidRector::class);
+    $rectorConfig->rule(ReplaceMediaImageFluidRector::class);
+    $rectorConfig->rule(ReplaceUriImageFluidRector::class);
     $rectorConfig->rule(ReplaceVariableSetFluidRector::class);
 };

--- a/config/replace-vhs.php
+++ b/config/replace-vhs.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceFormatJsonEncodeFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceLFluidRector;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceVariableSetFluidRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/config.php');
     $rectorConfig->rule(ReplaceFormatJsonEncodeFluidRector::class);
     $rectorConfig->rule(ReplaceLFluidRector::class);
+    $rectorConfig->rule(ReplaceVariableSetFluidRector::class);
 };

--- a/config/replace-vhs.php
+++ b/config/replace-vhs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceFormatJsonEncodeFluidRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/config.php');
+    $rectorConfig->rule(ReplaceFormatJsonEncodeFluidRector::class);
+};

--- a/config/replace-vhs.php
+++ b/config/replace-vhs.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceFormatJsonEncodeFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceLFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceMediaImageFluidRector;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceOrFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceUriImageFluidRector;
 use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceVariableSetFluidRector;
 
@@ -14,6 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ReplaceFormatJsonEncodeFluidRector::class);
     $rectorConfig->rule(ReplaceLFluidRector::class);
     $rectorConfig->rule(ReplaceMediaImageFluidRector::class);
+    $rectorConfig->rule(ReplaceOrFluidRector::class);
     $rectorConfig->rule(ReplaceUriImageFluidRector::class);
     $rectorConfig->rule(ReplaceVariableSetFluidRector::class);
 };

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceExtensionPathRelativeFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceExtensionPathRelativeFluidRector.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
+
+use Nette\Utils\Strings;
+use Rector\Core\Console\Output\RectorOutputStyle;
+use Rector\Core\ValueObject\Application\File;
+use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReplaceExtensionPathRelativeFluidRector implements FluidRectorInterface
+{
+    /**
+     * @var string
+     */
+    private const PATTERN_INLINE = '#{(v|vhs):extension\.path\.relative\(extensionName:(\s?)["\']([a-z0-9_]+)["\']\)}Resources\/Public\/(\S+)\.([a-z0-9]{2,4})#ims';
+
+    /**
+     * @var string
+     */
+    private const PATTERN_LEFTOVERS = '#(v|vhs):(extension\.path\.relative)#ims';
+
+    /**
+     * @readonly
+     */
+    private RectorOutputStyle $rectorOutputStyle;
+
+    public function __construct(RectorOutputStyle $rectorOutputStyle)
+    {
+        $this->rectorOutputStyle = $rectorOutputStyle;
+    }
+
+    public function transform(File $file): void
+    {
+        $content = $file->getFileContent();
+
+        $content = Strings::replace(
+            $content,
+            self::PATTERN_INLINE,
+            '{f:uri.resource(extensionName:\'\3\',path:\'\4.\5\')}'
+        );
+
+        if (Strings::matchAll($content, self::PATTERN_LEFTOVERS)) {
+            $this->rectorOutputStyle->warning('There\'s occurrences of v:extension.path.relative that couldn\'t be migrated automatically. Migrate them manually!');
+        }
+
+        $file->changeFileContent($content);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use <f:uri.resource> instead of <v:extension.path.relative>', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+{v:extension.path.relative(extensionName:'my_extension')}Resources/Public/Css/style.css
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+{f:uri.resource(extensionName:'my_extension',path:'Css/style.css')}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
+
+use Nette\Utils\Strings;
+use Rector\Core\ValueObject\Application\File;
+use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReplaceFormatJsonEncodeFluidRector implements FluidRectorInterface
+{
+    /**
+     * @var string
+     */
+    private const PATTERN = '#(v|vhs):format.json.encode#imsU';
+
+    /**
+     * @var string
+     */
+    private const REPLACEMENT = 'f:format.json';
+
+    public function transform(File $file): void
+    {
+        $content = $file->getFileContent();
+
+        $content = Strings::replace($content, self::PATTERN, self::REPLACEMENT);
+
+        $file->changeFileContent($content);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use <f:format.json> instead of <v:format.json.encode>', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+{someArray -> v:format.json.encode()}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+{someArray -> f:format.json()}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
+
+use Nette\Utils\Strings;
+use Rector\Core\ValueObject\Application\File;
+use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReplaceLFluidRector implements FluidRectorInterface
+{
+    /**
+     * @var string
+     */
+    private const PATTERN = '#(v|vhs):l([\( ])#imsU';
+
+    /**
+     * @var string
+     */
+    private const REPLACEMENT = 'f:translate$2';
+
+    public function transform(File $file): void
+    {
+        $content = $file->getFileContent();
+
+        $content = Strings::replace($content, self::PATTERN, self::REPLACEMENT);
+
+        $file->changeFileContent($content);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use <f:translate> instead of <v:l>', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+<v:l key="my-key" extensionName="my_extension" />
+<vhs:l key="my-other-key" />
+<v:loop ...>
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+<f:translate key="my-key" extensionName="my_extension" />
+<f:translate key="my-other-key" />
+<v:loop ...>
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector.php
@@ -39,7 +39,7 @@ final class ReplaceMediaImageFluidRector implements FluidRectorInterface
         return new RuleDefinition('Use <f:image> instead of <v:media.image>', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-<v:media src="{image.uid}" treatIdAsReference="true" />
+<v:media.image src="{image.uid}" treatIdAsReference="true" />
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
+
+use Nette\Utils\Strings;
+use Rector\Core\ValueObject\Application\File;
+use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReplaceMediaImageFluidRector implements FluidRectorInterface
+{
+    /**
+     * @var string
+     */
+    private const PATTERN = '#(v|vhs):media.image([\( ])#imsU';
+
+    /**
+     * @var string
+     */
+    private const REPLACEMENT = 'f:image$2';
+
+    public function transform(File $file): void
+    {
+        $content = $file->getFileContent();
+
+        // TODO 1: handle 'relative' attribute -> transform to inverted 'absolute'
+        // TODO 2: handle maxW attribute -> rename to maxWidth
+        // TODO 3: handle maxH attribute -> rename to maxHeight
+        $content = Strings::replace($content, self::PATTERN, self::REPLACEMENT);
+
+        $file->changeFileContent($content);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use <f:image> instead of <v:media.image>', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+<v:media src="{image.uid}" treatIdAsReference="true" />
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+<f:image src="{image.uid}" treatIdAsReference="true" />
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
+
+use Nette\Utils\Strings;
+use Rector\Core\ValueObject\Application\File;
+use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReplaceOrFluidRector implements FluidRectorInterface
+{
+    public function transform(File $file): void
+    {
+        $content = $file->getFileContent();
+
+        $content = Strings::replace(
+            $content,
+            '#-> (v|vhs):or\(alternative:(\s?)([^),]+)\)#ims',
+            '?: $3'
+        );
+
+        $content = Strings::replace(
+            $content,
+            '#(v|vhs):or\(content:(\s?)([^),]+),(\s?)alternative:(\s?)([^),]+)\)#ims',
+            '$3 ?: $6'
+        );
+
+        $file->changeFileContent($content);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use <f:or> instead of <v:or>', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+{someVariable -> v:or(alternative: 'Fallback text')}
+{v:or(content: someVariable, alternative: 'Fallback text')}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+{someVariable ?: 'Fallback text'}
+{someVariable ?: 'Fallback text'}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
+
+use Nette\Utils\Strings;
+use Rector\Core\ValueObject\Application\File;
+use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReplaceUriImageFluidRector implements FluidRectorInterface
+{
+    /**
+     * @var string
+     */
+    private const PATTERN = '#(v|vhs):uri.image#imsU';
+
+    /**
+     * @var string
+     */
+    private const REPLACEMENT = 'f:uri.image';
+
+    public function transform(File $file): void
+    {
+        $content = $file->getFileContent();
+
+        // TODO 1: handle 'relative' attribute -> transform to inverted 'absolute'
+        // TODO 2: handle maxW attribute -> rename to maxWidth
+        // TODO 3: handle maxH attribute -> rename to maxHeight
+        $content = Strings::replace($content, self::PATTERN, self::REPLACEMENT);
+
+        $file->changeFileContent($content);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use <f:uri.image> instead of <v:uri.image>', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+{v:uri.image(src:image.uid, treatIdAsReference: 1)}
+{v:uri.image(src:image.uid, treatIdAsReference: 1, relative: 1)}
+{v:uri.image(src:image.uid, treatIdAsReference: 1, relative: 0)}
+{v:uri.image(src:image.uid, treatIdAsReference: 1, maxW: 250, maxH: 250)}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+{f:uri.image(src:image.uid, treatIdAsReference: 1)}
+{f:uri.image(src:image.uid, treatIdAsReference: 1)}
+{f:uri.image(src:image.uid, treatIdAsReference: 1, absolute: 1)}
+{f:uri.image(src:image.uid, treatIdAsReference: 1, maxWidth: 250, maxHeight: 250)}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
 
 use Nette\Utils\Strings;
+use Rector\Core\Console\Output\RectorOutputStyle;
 use Rector\Core\ValueObject\Application\File;
 use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -15,18 +16,41 @@ final class ReplaceVariableSetFluidRector implements FluidRectorInterface
     /**
      * @var string
      */
-    private const PATTERN = '#(v|vhs):variable.set#imsU';
+    private const PATTERN_STRICT = '#(v|vhs):(variable.set)([\s(]name[:=]["\'])([a-z]+)(["\'])#imsU';
 
     /**
      * @var string
      */
-    private const REPLACEMENT = 'f:variable';
+    private const PATTERN_DOT = '#(v|vhs):(variable.set)([\s(]name[:=]["\'])([a-z\.]+)(["\'])#imsU';
+
+    /**
+     * @var string
+     */
+    private const PATTERN_LEFTOVERS = '#(v|vhs):(variable.set)#imsU';
+
+    /**
+     * @readonly
+     */
+    private RectorOutputStyle $rectorOutputStyle;
+
+    public function __construct(RectorOutputStyle $rectorOutputStyle)
+    {
+        $this->rectorOutputStyle = $rectorOutputStyle;
+    }
 
     public function transform(File $file): void
     {
         $content = $file->getFileContent();
 
-        $content = Strings::replace($content, self::PATTERN, self::REPLACEMENT);
+        $content = Strings::replace($content, self::PATTERN_STRICT, 'f:variable$3$4$5');
+
+        if (Strings::matchAll($content, self::PATTERN_DOT)) {
+            $this->rectorOutputStyle->warning('There\'s occurrences of v:variable.set that contain a dot in its name attribute and thus cannot be migrated to f:variable!');
+        }
+
+        if (Strings::matchAll($content, self::PATTERN_LEFTOVERS)) {
+            $this->rectorOutputStyle->warning('There\'s occurrences of v:variable.set that couldn\'t be migrated automatically. Migrate them manually!');
+        }
 
         $file->changeFileContent($content);
     }

--- a/src/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector.php
+++ b/src/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs;
+
+use Nette\Utils\Strings;
+use Rector\Core\ValueObject\Application\File;
+use Ssch\TYPO3Rector\Contract\FileProcessor\Fluid\Rector\FluidRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReplaceVariableSetFluidRector implements FluidRectorInterface
+{
+    /**
+     * @var string
+     */
+    private const PATTERN = '#(v|vhs):variable.set#imsU';
+
+    /**
+     * @var string
+     */
+    private const REPLACEMENT = 'f:variable';
+
+    public function transform(File $file): void
+    {
+        $content = $file->getFileContent();
+
+        $content = Strings::replace($content, self::PATTERN, self::REPLACEMENT);
+
+        $file->changeFileContent($content);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use <f:variable> instead of <v:variable.set>', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+<v:variable.set name="myvariable" value="a string value" />
+{myvariable -> v:variable.set(name:'othervariable')}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+<f:variable name="myvariable" value="a string value" />
+{myvariable -> f:variable(name:'othervariable')}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+}

--- a/src/Set/Extension/VhsSetList.php
+++ b/src/Set/Extension/VhsSetList.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Set\Extension;
+
+final class VhsSetList
+{
+    /**
+     * @var string
+     */
+    public const REPLACE_VHS = __DIR__ . '/../../../config/replace-vhs.php';
+}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector/Fixture/fixture.html.inc
@@ -1,0 +1,5 @@
+{someArray -> v:format.json.encode()}
+<v:format.json.encode value="{someArray}" />
+-----
+{someArray -> f:format.json()}
+<f:format.json value="{someArray}" />

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector/ReplaceFormatJsonEncodeFluidRectorTest.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector/ReplaceFormatJsonEncodeFluidRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\FileProcessor\Fluid\Rector\vhs\ReplaceOrFluidRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceFormatJsonEncodeFluidRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.html.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector/config/configured_rule.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceFormatJsonEncodeFluidRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceFormatJsonEncodeFluidRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../../config/config_test.php');
+    $rectorConfig->rule(ReplaceFormatJsonEncodeFluidRector::class);
+};

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector/Fixture/fixture.html.inc
@@ -1,0 +1,7 @@
+<v:l key="my-key" extensionName="my_extension" />
+<vhs:l key="my-other-key" />
+<v:loop ...>
+-----
+<f:translate key="my-key" extensionName="my_extension" />
+<f:translate key="my-other-key" />
+<v:loop ...>

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector/ReplaceLFluidRectorTest.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector/ReplaceLFluidRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\FileProcessor\Fluid\Rector\vhs\ReplaceLFluidRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceLFluidRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.html.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector/config/configured_rule.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceLFluidRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceLFluidRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../../config/config_test.php');
+    $rectorConfig->rule(ReplaceLFluidRector::class);
+};

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector/Fixture/fixture.html.inc
@@ -1,0 +1,3 @@
+<v:media.image src="{image.uid}" treatIdAsReference="true" />
+-----
+<f:image src="{image.uid}" treatIdAsReference="true" />

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector/ReplaceMediaImageFluidRectorTest.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector/ReplaceMediaImageFluidRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\FileProcessor\Fluid\Rector\vhs\ReplaceMediaImageFluidRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceMediaImageFluidRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.html.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector/config/configured_rule.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceMediaImageFluidRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceMediaImageFluidRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../../config/config_test.php');
+    $rectorConfig->rule(ReplaceMediaImageFluidRector::class);
+};

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector/Fixture/fixture.html.inc
@@ -1,0 +1,5 @@
+{someVariable -> v:or(alternative:'Fallback text')}
+{v:or(content: someVariable, alternative: 'Fallback text')}
+-----
+{someVariable ?: 'Fallback text'}
+{someVariable ?: 'Fallback text'}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector/ReplaceOrFluidRectorTest.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector/ReplaceOrFluidRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\FileProcessor\Fluid\Rector\vhs\ReplaceOrFluidRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceOrFluidRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.html.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector/config/configured_rule.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceOrFluidRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceOrFluidRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../../config/config_test.php');
+    $rectorConfig->rule(ReplaceOrFluidRector::class);
+};

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/Fixture/fixture.html.inc
@@ -1,0 +1,9 @@
+{v:uri.image(src:image.uid, treatIdAsReference: 1)}
+{v:uri.image(src:image.uid, treatIdAsReference: 1, relative: 1)}
+{v:uri.image(src:image.uid, treatIdAsReference: 1, relative: 0)}
+{v:uri.image(src:image.uid, treatIdAsReference: 1, maxW: 250, maxH: 250)}
+-----
+{f:uri.image(src:image.uid, treatIdAsReference: 1)}
+{f:uri.image(src:image.uid, treatIdAsReference: 1)}
+{f:uri.image(src:image.uid, treatIdAsReference: 1, absolute: 1)}
+{f:uri.image(src:image.uid, treatIdAsReference: 1, maxWidth: 250, maxHeight: 250)}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/Fixture/fixture.html.inc
@@ -1,9 +1,3 @@
 {v:uri.image(src:image.uid, treatIdAsReference: 1)}
-{v:uri.image(src:image.uid, treatIdAsReference: 1, relative: 1)}
-{v:uri.image(src:image.uid, treatIdAsReference: 1, relative: 0)}
-{v:uri.image(src:image.uid, treatIdAsReference: 1, maxW: 250, maxH: 250)}
 -----
 {f:uri.image(src:image.uid, treatIdAsReference: 1)}
-{f:uri.image(src:image.uid, treatIdAsReference: 1)}
-{f:uri.image(src:image.uid, treatIdAsReference: 1, absolute: 1)}
-{f:uri.image(src:image.uid, treatIdAsReference: 1, maxWidth: 250, maxHeight: 250)}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/ReplaceUriImageFluidRectorTest.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/ReplaceUriImageFluidRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\FileProcessor\Fluid\Rector\vhs\ReplaceUriImageFluidRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceUriImageFluidRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.html.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/config/configured_rule.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceUriImageFluidRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceUriImageFluidRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../../config/config_test.php');
+    $rectorConfig->rule(ReplaceUriImageFluidRector::class);
+};

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/Fixture/fixture.html.inc
@@ -1,0 +1,5 @@
+<v:variable.set name="myvariable" value="a string value" />
+{myvariable -> v:variable.set(name:'othervariable')}
+-----
+<f:variable name="myvariable" value="a string value" />
+{myvariable -> f:variable(name:'othervariable')}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/Fixture/fixture.html.inc
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/Fixture/fixture.html.inc
@@ -1,5 +1,15 @@
-<v:variable.set name="myvariable" value="a string value" />
+Simple (and easily migratable) cases:
 {myvariable -> v:variable.set(name:'othervariable')}
+<v:variable.set name="myvariable" value="a string value" />
+
+More complex cases (and unmigratable) cases:
+<v:variable.set name="myarray.property" value="a string value" />
+<v:variable.set value="a string value" name="myvariable" />
 -----
-<f:variable name="myvariable" value="a string value" />
+Simple (and easily migratable) cases:
 {myvariable -> f:variable(name:'othervariable')}
+<f:variable name="myvariable" value="a string value" />
+
+More complex cases (and unmigratable) cases:
+<v:variable.set name="myarray.property" value="a string value" />
+<v:variable.set value="a string value" name="myvariable" />

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/ReplaceVariableSetFluidRectorTest.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/ReplaceVariableSetFluidRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\FileProcessor\Fluid\Rector\vhs\ReplaceVariableSetFluidRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceVariableSetFluidRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.html.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/config/configured_rule.php
+++ b/tests/FileProcessor/Fluid/Rector/vhs/ReplaceVariableSetFluidRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\FileProcessor\Fluid\Rector\vhs\ReplaceVariableSetFluidRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../../config/config_test.php');
+    $rectorConfig->rule(ReplaceVariableSetFluidRector::class);
+};


### PR DESCRIPTION
* v:extension.path.relative -> f:uri.resource
* v:format.json.encode -> f:format.json
* v:media.image -> f:media.image
* v:uri.image -> f:uri.image
* v:l -> f:translate
* v:variable.set -> f:variable
* v:or -> inline ternary operator

t.b.c.