### PR TITLE
[BUGFIX] Prevent false migration from type input to type number

### DIFF
--- a/src/Rector/v12/v0/flexform/MigrateEvalIntAndDouble2ToTypeNumberFlexFormRector.php
+++ b/src/Rector/v12/v0/flexform/MigrateEvalIntAndDouble2ToTypeNumberFlexFormRector.php
@@ -120,23 +120,25 @@ CODE_SAMPLE
             return;
         }
 
-        if (StringUtility::inList($evalListValue, self::INT) || StringUtility::inList($evalListValue, self::DOUBLE2)) {
-            $evalList = ArrayUtility::trimExplode(',', $evalListValue, true);
+        if (! StringUtility::inList($evalListValue, self::INT) && ! StringUtility::inList($evalListValue, self::DOUBLE2)) {
+            return;
+        }
 
-            // Remove "int" from $evalList
-            $evalList = array_filter(
-                $evalList,
-                static fn (string $eval) => $eval !== self::INT && $eval !== self::DOUBLE2
-            );
+        $evalList = ArrayUtility::trimExplode(',', $evalListValue, true);
 
-            if ($evalList !== []) {
-                // Write back filtered 'eval'
-                $evalDomElement->nodeValue = '';
-                $evalDomElement->appendChild($domDocument->createTextNode(implode(',', $evalList)));
-            } elseif ($evalDomElement->parentNode instanceof DOMElement) {
-                // 'eval' is empty, remove whole configuration
-                $evalDomElement->parentNode->removeChild($evalDomElement);
-            }
+        // Remove "int" from $evalList
+        $evalList = array_filter(
+            $evalList,
+            static fn (string $eval) => $eval !== self::INT && $eval !== self::DOUBLE2
+        );
+
+        if ($evalList !== []) {
+            // Write back filtered 'eval'
+            $evalDomElement->nodeValue = '';
+            $evalDomElement->appendChild($domDocument->createTextNode(implode(',', $evalList)));
+        } elseif ($evalDomElement->parentNode instanceof DOMElement) {
+            // 'eval' is empty, remove whole configuration
+            $evalDomElement->parentNode->removeChild($evalDomElement);
         }
 
         $toChangeItem = $this->extractDomElementByKey($configElement, 'type');

--- a/src/Rector/v12/v0/tca/MigrateEvalIntAndDouble2ToTypeNumberRector.php
+++ b/src/Rector/v12/v0/tca/MigrateEvalIntAndDouble2ToTypeNumberRector.php
@@ -103,22 +103,24 @@ CODE_SAMPLE
             return;
         }
 
-        if (StringUtility::inList($evalListValue, self::INT) || StringUtility::inList($evalListValue, self::DOUBLE2)) {
-            $evalList = ArrayUtility::trimExplode(',', $evalListValue, true);
+        if (! StringUtility::inList($evalListValue, self::INT) && ! StringUtility::inList($evalListValue, self::DOUBLE2)) {
+            return;
+        }
 
-            // Remove "int" from $evalList
-            $evalList = array_filter(
-                $evalList,
-                static fn (string $eval) => $eval !== self::INT && $eval !== self::DOUBLE2
-            );
+        $evalList = ArrayUtility::trimExplode(',', $evalListValue, true);
 
-            if ($evalList !== []) {
-                // Write back filtered 'eval'
-                $evalArrayItem->value = new String_(implode(',', $evalList));
-            } else {
-                // 'eval' is empty, remove whole configuration
-                $this->removeNode($evalArrayItem);
-            }
+        // Remove "int" from $evalList
+        $evalList = array_filter(
+            $evalList,
+            static fn (string $eval) => $eval !== self::INT && $eval !== self::DOUBLE2
+        );
+
+        if ($evalList !== []) {
+            // Write back filtered 'eval'
+            $evalArrayItem->value = new String_(implode(',', $evalList));
+        } else {
+            // 'eval' is empty, remove whole configuration
+            $this->removeNode($evalArrayItem);
         }
 
         $toChangeArrayItem = $this->extractArrayItemByKey($configArray, 'type');

--- a/tests/Rector/v12/v0/flexform/MigrateEvalIntAndDouble2ToTypeNumberFlexFormRector/Fixture/fixture.xml.inc
+++ b/tests/Rector/v12/v0/flexform/MigrateEvalIntAndDouble2ToTypeNumberFlexFormRector/Fixture/fixture.xml.inc
@@ -5,6 +5,13 @@
                 <sheetTitle>sheetTitle</sheetTitle>
                 <type>array</type>
                 <el>
+                    <settings.input_field>
+                        <label>Input field</label>
+                        <config>
+                            <type>input</type>
+                            <eval>trim</eval>
+                        </config>
+                    </settings.input_field>
                     <settings.int_field>
                         <label>Int field</label>
                         <config>
@@ -39,6 +46,13 @@
                 <sheetTitle>sheetTitle</sheetTitle>
                 <type>array</type>
                 <el>
+                    <settings.input_field>
+                        <label>Input field</label>
+                        <config>
+                            <type>input</type>
+                            <eval>trim</eval>
+                        </config>
+                    </settings.input_field>
                     <settings.int_field>
                         <label>Int field</label>
                         <config>

--- a/tests/Rector/v12/v0/tca/MigrateEvalIntAndDouble2ToTypeNumberRector/Fixture/fixture.php.inc
+++ b/tests/Rector/v12/v0/tca/MigrateEvalIntAndDouble2ToTypeNumberRector/Fixture/fixture.php.inc
@@ -5,6 +5,13 @@ namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\tca\MigrateEvalIntAndDouble2ToTyp
 return [
     'ctrl' => [],
     'columns' => [
+        'non_int_field_with_eval_defined' => [
+            'label' => 'input field',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim',
+            ],
+        ],
         'int_field' => [
             'label' => 'int field',
             'config' => [
@@ -51,6 +58,13 @@ namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\tca\MigrateEvalIntAndDouble2ToTyp
 return [
     'ctrl' => [],
     'columns' => [
+        'non_int_field_with_eval_defined' => [
+            'label' => 'input field',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim',
+            ],
+        ],
         'int_field' => [
             'label' => 'int field',
             'config' => [


### PR DESCRIPTION
An early return is added, in case the eval list doesn't contain neither `int` nor `double`.

Fixes: #3923