### PR TITLE
[TASK] Narrow down the Symfony development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
         "phpstan/extension-installer": "^1.3.1",
         "phpstan/phpstan-phpunit": "^1.3.15",
         "phpunit/phpunit": "^9.6.16",
-        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
+        "symfony/dependency-injection": "^5.4.34 || ^6.4.2 || ^7.0.2",
+        "symfony/http-kernel": "^5.4.34 || ^6.4.2 || ^7.0.2",
         "symplify/easy-coding-standard": "^12.1.8"
     },
     "autoload": {


### PR DESCRIPTION
The Symfony development dependencies do not need to be in sync with the TYPO3 Core Symfony dependencies as they are not installed in projects that have this package as a dependency. Instead, it suffices that the set of development dependencies is installable (and works) with the PHP versions we support.