### PR TITLE
Leave FQCN unchanged

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -13,10 +13,7 @@ use Ssch\TYPO3Rector\NodeResolver\Typo3NodeResolver;
 use Ssch\TYPO3Rector\Yaml\SymfonyYamlParser;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->importNames();
     $rectorConfig->phpstanConfig(Typo3Option::PHPSTAN_FOR_RECTOR_PATH);
-    // this will not import root namespace classes, like \DateTime or \Exception
-    $rectorConfig->importShortClasses(false);
 
     $rectorConfig->singleton(FileInfoFactory::class);
     $rectorConfig->singleton(FilesFinder::class);


### PR DESCRIPTION
Existing FQCN should not be changed as drive-by-change but willingly and explicitly in each project instead. This also reduces the diff in many cases and thus simplifies selectively committing Rector changes.

See https://github.com/sabbelasichon/typo3-rector/discussions/2972