### PR TITLE
Fix typos in Rector descriptions

### DIFF
--- a/docs/all_rectors_overview.md
+++ b/docs/all_rectors_overview.md
@@ -686,7 +686,7 @@ Substitute deprecated method calls of class GeneralUtility
 
 ### SubstituteResourceFactoryRector
 
-Substitue `ResourceFactory::getInstance()` through GeneralUtility::makeInstance(ResourceFactory::class)
+Substitute `ResourceFactory::getInstance()` through GeneralUtility::makeInstance(ResourceFactory::class)
 
 - class: [`Ssch\TYPO3Rector\TYPO310\v3\SubstituteResourceFactoryRector`](../rules/TYPO310/v3/SubstituteResourceFactoryRector.php)
 
@@ -858,7 +858,7 @@ Use controller classes when registering extbase plugins/modules
 
 ### UseFileGetContentsForGetUrlRector
 
-Rewirte Method Calls of GeneralUtility::getUrl("somefile.csv") to `@file_get_contents`
+Rewrite Method Calls of GeneralUtility::getUrl("somefile.csv") to `@file_get_contents`
 
 - class: [`Ssch\TYPO3Rector\TYPO310\v4\UseFileGetContentsForGetUrlRector`](../rules/TYPO310/v4/UseFileGetContentsForGetUrlRector.php)
 
@@ -924,7 +924,7 @@ Turns TYPO3\CMS\Extbase\Utility\TypeHandlingUtility::hex2bin calls to native php
 
 ### UseTwoLetterIsoCodeFromSiteLanguageRector
 
-The usage of the propery sys_language_isocode is deprecated. Use method getTwoLetterIsoCode of SiteLanguage
+The usage of the property sys_language_isocode is deprecated. Use method getTwoLetterIsoCode of SiteLanguage
 
 - class: [`Ssch\TYPO3Rector\TYPO310\v0\UseTwoLetterIsoCodeFromSiteLanguageRector`](../rules/TYPO310/v0/UseTwoLetterIsoCodeFromSiteLanguageRector.php)
 

--- a/rules/TYPO310/v0/UseTwoLetterIsoCodeFromSiteLanguageRector.php
+++ b/rules/TYPO310/v0/UseTwoLetterIsoCodeFromSiteLanguageRector.php
@@ -71,7 +71,7 @@ final class UseTwoLetterIsoCodeFromSiteLanguageRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'The usage of the propery sys_language_isocode is deprecated. Use method getTwoLetterIsoCode of SiteLanguage',
+            'The usage of the property sys_language_isocode is deprecated. Use method getTwoLetterIsoCode of SiteLanguage',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/TYPO310/v3/SubstituteResourceFactoryRector.php
+++ b/rules/TYPO310/v3/SubstituteResourceFactoryRector.php
@@ -51,7 +51,7 @@ final class SubstituteResourceFactoryRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Substitue ResourceFactory::getInstance() through GeneralUtility::makeInstance(ResourceFactory::class)',
+            'Substitute ResourceFactory::getInstance() through GeneralUtility::makeInstance(ResourceFactory::class)',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/TYPO310/v4/UseFileGetContentsForGetUrlRector.php
+++ b/rules/TYPO310/v4/UseFileGetContentsForGetUrlRector.php
@@ -87,7 +87,7 @@ final class UseFileGetContentsForGetUrlRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Rewirte Method Calls of GeneralUtility::getUrl("somefile.csv") to @file_get_contents',
+            'Rewrite Method Calls of GeneralUtility::getUrl("somefile.csv") to @file_get_contents',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'


### PR DESCRIPTION
This fixes 3 typos in the descriptions of Rector rules and in the aggregated documentation. 