### PR TITLE
[TASK] Import classes possible since TYPO3 11.4

### DIFF
--- a/templates/rector.php.dist
+++ b/templates/rector.php.dist
@@ -37,16 +37,14 @@ __PATHS__
         ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-12.4.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => []
     ])
-    # If you use importNames(), you should consider excluding some TYPO3 files.
+    # If you use withImportNames(), you should consider excluding some TYPO3 files.
     ->withSkip([
         // @see https://github.com/sabbelasichon/typo3-rector/issues/2536
         __DIR__ . '/**/Configuration/ExtensionBuilder/*',
         NameImportingPostRector::class => [
-            'ext_localconf.php',
-            'ext_tables.php',
+            'ext_localconf.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html
+            'ext_tables.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html
             'ClassAliasMap.php',
-            __DIR__ . '/**/Configuration/*.php',
-            __DIR__ . '/**/Configuration/**/*.php',
         ]
     ])
 ;


### PR DESCRIPTION
Importing classes in Configuration was possible with older TYPO3 versions already.

Resolves: #2644