### PR TITLE
[BUGFIX] Skip checkboxes that have a migrated label key

### DIFF
--- a/rules/TYPO311/v5/SimplifyCheckboxItemsTCARector.php
+++ b/rules/TYPO311/v5/SimplifyCheckboxItemsTCARector.php
@@ -136,6 +136,12 @@ CODE_SAMPLE
             return;
         }
 
+        $labelKeyArrayItem = $this->extractArrayItemByKey($firstItemsArray, 'label');
+        if ($labelKeyArrayItem instanceof ArrayItem) {
+            // Skip migrated items which have a "label" key that comes from MigrateItemsIndexedKeysToAssociativeRector.
+            return;
+        }
+
         // Remove the whole items array
         $this->removeArrayItemFromArrayByKey($configArray, 'items');
     }

--- a/tests/Rector/v11/v5/SimplifyCheckboxItemsTCARector/Fixture/bug_4238.php.inc
+++ b/tests/Rector/v11/v5/SimplifyCheckboxItemsTCARector/Fixture/bug_4238.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v11\v5\SimplifyCheckboxItemsTCARector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'show_canonical' => [
+            'exclude' => 1,
+            'l10n_mode' => 'mergeIfNotBlank',
+            'label' => 'show_canonical',
+            'config' => [
+                'type' => 'check',
+                'renderType' => 'checkboxToggle',
+                'invertStateDisplay' => '1',
+                'items' => [
+                    ['label' => ''],
+                ],
+            ],
+        ],
+        'no_archive' => [
+            'exclude' => 1,
+            'l10n_mode' => 'exclude',
+            'label' => 'no_archive',
+            'config' => [
+                'type' => 'check',
+                'renderType' => 'checkboxToggle',
+                'items' => [
+                    ['label' => ''],
+                ],
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
Resolves: #4238