### PR TITLE
[TASK] Allow nikic/php-parser v5 for TYPO3 13.1.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "league/flysystem": "^2.0",
         "league/flysystem-memory": "^2.0",
         "nette/utils": "^3.2.10 || ^4.0.4",
-        "nikic/php-parser": "^4.18.0",
+        "nikic/php-parser": "^4.18.0 || ^5.0.1",
         "phpstan/phpstan": "^1.10.56",
         "rector/rector": "^1.0",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",


### PR DESCRIPTION
Fixes: #4247