### PR TITLE
[BUGFIX] fix usages of allowTableOnStandardPages with mutliple tablenames in one string

### DIFF
--- a/rules/TYPO312/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector.php
+++ b/rules/TYPO312/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector.php
@@ -87,12 +87,16 @@ CODE_SAMPLE
             return null;
         }
 
-        $tableName = $this->valueResolver->getValue($tableArgument);
+        $tableNames = $this->valueResolver->getValue($tableArgument);
 
-        $directoryName = dirname($this->file->getFilePath());
-        $newConfigurationFile = $directoryName . '/Configuration/TCA/Overrides/' . $tableName . '.php';
-        $this->writeConfigurationToFile($newConfigurationFile, $tableName);
-
+        foreach (explode(',', $tableNames) as $tableName) {
+            if (!$tableName) {
+                continue;
+            }
+            $directoryName = dirname($this->file->getFilePath());
+            $newConfigurationFile = $directoryName . '/Configuration/TCA/Overrides/' . $tableName . '.php';
+            $this->writeConfigurationToFile($newConfigurationFile, $tableName);
+        }
         return NodeTraverser::REMOVE_NODE;
     }
 

--- a/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/Assertions/tx_table_one.php.inc
+++ b/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/Assertions/tx_table_one.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TCA']['tx_table_one']['ctrl']['security']['ignorePageTypeRestriction'] = true;

--- a/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/Assertions/tx_table_two.php.inc
+++ b/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/Assertions/tx_table_two.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TCA']['tx_table_two']['ctrl']['security']['ignorePageTypeRestriction'] = true;

--- a/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/Fixture/ext_tables.php.inc
+++ b/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/Fixture/ext_tables.php.inc
@@ -6,6 +6,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 ExtensionManagementUtility::allowTableOnStandardPages('tx_table_with_existing_tca_configuration_file');
 ExtensionManagementUtility::allowTableOnStandardPages('tx_table_without_existing_tca_configuration_file');
+ExtensionManagementUtility::allowTableOnStandardPages('tx_table_one,tx_table_two');
 
 ?>
 -----

--- a/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/MoveAllowTableOnStandardPagesToTCAConfigurationRectorTest.php
+++ b/tests/Rector/v12/v0/MoveAllowTableOnStandardPagesToTCAConfigurationRector/MoveAllowTableOnStandardPagesToTCAConfigurationRectorTest.php
@@ -39,6 +39,14 @@ CODE
             __DIR__ . '/Fixture/Configuration/TCA/Overrides/%s.php',
             'tx_table_with_existing_tca_configuration_file'
         );
+        $this->assertThatConfigurationFileHasNewIgnorePageTypeRestriction(
+            __DIR__ . '/Fixture/Configuration/TCA/Overrides/%s.php',
+            'tx_table_one'
+        );
+        $this->assertThatConfigurationFileHasNewIgnorePageTypeRestriction(
+            __DIR__ . '/Fixture/Configuration/TCA/Overrides/%s.php',
+            'tx_table_two'
+        );
     }
 
     public function provideConfigFilePath(): string


### PR DESCRIPTION
currently if you have a config like this:
````php
ExtensionManagementUtility::allowTableOnStandardPages('tx_table_one,tx_table_two');
````
That will create a file like this:
`Configuration/TCA/Overrides/tx_table_one,tx_table_two.php`
With this PR it will create 2 files instead.