### PR TITLE
Remove use of protected property NodeNameResolver on Rector Rules

### DIFF
--- a/rules/CodeQuality/General/MethodGetInstanceToMakeInstanceCallRector.php
+++ b/rules/CodeQuality/General/MethodGetInstanceToMakeInstanceCallRector.php
@@ -54,7 +54,7 @@ final class MethodGetInstanceToMakeInstanceCallRector extends AbstractRector imp
             return null;
         }
 
-        $className = $this->nodeNameResolver->getName($node->class);
+        $className = $this->getName($node->class);
 
         if ($className === null) {
             return null;

--- a/rules/TYPO310/v0/RemoveFormatConstantsEmailFinisherRector.php
+++ b/rules/TYPO310/v0/RemoveFormatConstantsEmailFinisherRector.php
@@ -126,7 +126,7 @@ CODE_SAMPLE
         }
 
         $methodCall->args[0]->value = new String_(self::ADD_HTML_PART);
-        $methodCall->args[1]->value = $this->nodeNameResolver->isName(
+        $methodCall->args[1]->value = $this->isName(
             $classConstFetch->name,
             self::FORMAT_HTML
         ) ? $this->nodeFactory->createTrue() : $this->nodeFactory->createFalse();

--- a/rules/TYPO311/v2/SubstituteEnvironmentServiceWithApplicationTypeRector.php
+++ b/rules/TYPO311/v2/SubstituteEnvironmentServiceWithApplicationTypeRector.php
@@ -83,7 +83,7 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->nodeNameResolver->isNames(
+        return ! $this->isNames(
             $node->name,
             ['isEnvironmentInFrontendMode', 'isEnvironmentInBackendMode']
         );

--- a/rules/TYPO311/v3/SubstituteMethodRmFromListOfGeneralUtilityRector.php
+++ b/rules/TYPO311/v3/SubstituteMethodRmFromListOfGeneralUtilityRector.php
@@ -60,7 +60,7 @@ final class SubstituteMethodRmFromListOfGeneralUtilityRector extends AbstractRec
         $explodeFuncCall = $this->nodeFactory->createFuncCall('explode', [',', $node->args[1]]);
 
         $itemVariable = new Variable('item');
-        $elementVariable = new Variable($this->nodeNameResolver->getName($node->args[0]->value) ?? 'element');
+        $elementVariable = new Variable($this->getName($node->args[0]->value) ?? 'element');
 
         $stmts = [new Return_(new Equal($elementVariable, $itemVariable))];
 

--- a/rules/TYPO311/v4/AddSetConfigurationMethodToExceptionHandlerRector.php
+++ b/rules/TYPO311/v4/AddSetConfigurationMethodToExceptionHandlerRector.php
@@ -189,7 +189,7 @@ CODE_SAMPLE
                 return false;
             }
 
-            return $this->nodeNameResolver->isName($node, $firstParameterName);
+            return $this->isName($node, $firstParameterName);
         });
 
         if ($variables === []) {

--- a/rules/TYPO311/v4/UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector.php
+++ b/rules/TYPO311/v4/UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector.php
@@ -58,7 +58,7 @@ final class UseNativeFunctionInsteadOfGeneralUtilityShortMd5Rector extends Abstr
             return null;
         }
 
-        if (! $this->nodeNameResolver->isName($node->name, 'shortMD5')) {
+        if (! $this->isName($node->name, 'shortMD5')) {
             return null;
         }
 

--- a/rules/TYPO311/v5/SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector.php
+++ b/rules/TYPO311/v5/SubstituteGetIconFactoryAndGetPageRendererFromModuleTemplateRector.php
@@ -156,7 +156,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            if (! $this->nodeNameResolver->isName($node->name, $methodCallName)) {
+            if (! $this->isName($node->name, $methodCallName)) {
                 return null;
             }
 

--- a/rules/TYPO312/v0/ChangeExtbaseValidatorsRector.php
+++ b/rules/TYPO312/v0/ChangeExtbaseValidatorsRector.php
@@ -187,7 +187,7 @@ CODE_SAMPLE
         $assignToOptionsProperty = false;
         $constructorParams = [];
         foreach ($constructorMethod->getParams() as $param) {
-            if ($this->nodeNameResolver->isName($param, 'options')) {
+            if ($this->isName($param, 'options')) {
                 $assignToOptionsProperty = true;
                 continue;
             }
@@ -216,7 +216,7 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->nodeNameResolver->isName($assign->var, 'options');
+        return ! $this->isName($assign->var, 'options');
     }
 
     private function shouldKeepStaticCall(StaticCall $staticCall): bool

--- a/rules/TYPO312/v0/MigrateContentObjectRendererGetTypoLinkUrlRector.php
+++ b/rules/TYPO312/v0/MigrateContentObjectRendererGetTypoLinkUrlRector.php
@@ -136,6 +136,6 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->nodeNameResolver->isName($node->name, 'getTypoLink_URL');
+        return ! $this->isName($node->name, 'getTypoLink_URL');
     }
 }

--- a/rules/TYPO312/v0/MigrateFetchAllToFetchAllAssociativeRector.php
+++ b/rules/TYPO312/v0/MigrateFetchAllToFetchAllAssociativeRector.php
@@ -138,6 +138,6 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->nodeNameResolver->isName($node->name, 'fetchAll');
+        return ! $this->isName($node->name, 'fetchAll');
     }
 }

--- a/rules/TYPO312/v0/MigrateFetchColumnToFetchOneRector.php
+++ b/rules/TYPO312/v0/MigrateFetchColumnToFetchOneRector.php
@@ -69,6 +69,6 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->nodeNameResolver->isName($node->name, 'fetchColumn');
+        return ! $this->isName($node->name, 'fetchColumn');
     }
 }

--- a/rules/TYPO312/v0/MigrateFetchToFetchAssociativeRector.php
+++ b/rules/TYPO312/v0/MigrateFetchToFetchAssociativeRector.php
@@ -138,6 +138,6 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->nodeNameResolver->isName($node->name, 'fetch');
+        return ! $this->isName($node->name, 'fetch');
     }
 }

--- a/rules/TYPO312/v0/UseConfigArrayForTSFEPropertiesRector.php
+++ b/rules/TYPO312/v0/UseConfigArrayForTSFEPropertiesRector.php
@@ -59,11 +59,11 @@ final class UseConfigArrayForTSFEPropertiesRector extends AbstractRector impleme
             return null;
         }
 
-        if (! $this->nodeNameResolver->isNames($node->name, self::DEPRECATED_PUBLIC_PROPERTIES)) {
+        if (! $this->isNames($node->name, self::DEPRECATED_PUBLIC_PROPERTIES)) {
             return null;
         }
 
-        $propertyName = $this->nodeNameResolver->getName($node->name);
+        $propertyName = $this->getName($node->name);
 
         if ($propertyName === null) {
             return null;

--- a/rules/TYPO312/v4/CommandConfigurationToAttributeRector.php
+++ b/rules/TYPO312/v4/CommandConfigurationToAttributeRector.php
@@ -275,7 +275,7 @@ CODE_SAMPLE
         $replacedAsCommandAttribute = \false;
         foreach ($class->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attribute) {
-                if ($this->nodeNameResolver->isName($attribute->name, SymfonyAttribute::AS_COMMAND)) {
+                if ($this->isName($attribute->name, SymfonyAttribute::AS_COMMAND)) {
                     $hasAsCommandAttribute = \true;
                     $replacedAsCommandAttribute = $this->replaceArguments($attribute, $createAttributeGroup);
                 }

--- a/rules/TYPO313/v0/EventListenerConfigurationToAttributeRector.php
+++ b/rules/TYPO313/v0/EventListenerConfigurationToAttributeRector.php
@@ -199,7 +199,7 @@ CODE_SAMPLE
         $replacedAsEventListenerAttribute = \false;
         foreach ($class->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attribute) {
-                if ($this->nodeNameResolver->isName($attribute->name, 'TYPO3\CMS\Core\Attribute\AsEventListener')) {
+                if ($this->isName($attribute->name, 'TYPO3\CMS\Core\Attribute\AsEventListener')) {
                     $hasAsEventListenerAttribute = \true;
                     $replacedAsEventListenerAttribute = $this->replaceArguments($attribute, $createAttributeGroup);
                 }

--- a/rules/TYPO313/v2/MigrateRegularExpressionValidatorValidatorOptionErrorMessageRector.php
+++ b/rules/TYPO313/v2/MigrateRegularExpressionValidatorValidatorOptionErrorMessageRector.php
@@ -98,7 +98,7 @@ CODE_SAMPLE
 
     private function shouldSkip(Attribute $attribute): bool
     {
-        if (! $this->nodeNameResolver->isName($attribute, 'TYPO3\CMS\Extbase\Annotation\Validate')) {
+        if (! $this->isName($attribute, 'TYPO3\CMS\Extbase\Annotation\Validate')) {
             return true;
         }
 

--- a/rules/TYPO313/v3/MigrateViewHelperRenderStaticRector.php
+++ b/rules/TYPO313/v3/MigrateViewHelperRenderStaticRector.php
@@ -92,9 +92,9 @@ CODE_SAMPLE
         }
 
         // Replacements for renderStatic() method arguments
-        $argumentsParamName = $this->nodeNameResolver->getName($staticMethodNode->params[0]->var);
-        $renderClosureParamName = $this->nodeNameResolver->getName($staticMethodNode->params[1]->var);
-        $renderingContextParamName = $this->nodeNameResolver->getName($staticMethodNode->params[2]->var);
+        $argumentsParamName = $this->getName($staticMethodNode->params[0]->var);
+        $renderClosureParamName = $this->getName($staticMethodNode->params[1]->var);
+        $renderingContextParamName = $this->getName($staticMethodNode->params[2]->var);
 
         // Replace local variables in render function with object properties
         $this->traverseNodesWithCallable(
@@ -118,14 +118,14 @@ CODE_SAMPLE
                 if (
                     $node instanceof FuncCall
                     && $node->name instanceof Variable
-                    && $this->nodeNameResolver->getName($node->name) === $renderClosureParamName
+                    && $this->getName($node->name) === $renderClosureParamName
                 ) {
                     return $childrenClosureCallReplacement;
                 }
 
                 // Replace usages of variables
                 if ($node instanceof Variable) {
-                    switch ($this->nodeNameResolver->getName($node)) {
+                    switch ($this->getName($node)) {
                         case $argumentsParamName:
                             return $argumentsReplacement;
 


### PR DESCRIPTION
Rector is removing use of protected property `nodeNameResolver` in rules, use `isName()`, `isNames()`, `getName()` directly instead. Ref PR:

- https://github.com/rectorphp/rector-src/pull/6875