### PR TITLE
[BUGFIX] Skip migration if target class already has a constructor

### DIFF
--- a/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Fixture/skip_if_constructor_in_parent_class.php.inc
+++ b/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Fixture/skip_if_constructor_in_parent_class.php.inc
@@ -1,0 +1,67 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Fixture;
+
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\AnotherService;
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\YetAnotherService;
+
+class BaseServiceWithConstructor
+{
+    protected YetAnotherService $baseDep;
+
+    public function __construct(YetAnotherService $baseDep)
+    {
+        $this->baseDep = $baseDep;
+    }
+}
+
+class SkipIfConstructorInParentClass extends BaseServiceWithConstructor
+{
+    private AnotherService $anotherService;
+
+    // This inject method should not be processed because BaseServiceWithConstructor has a constructor
+    public function injectAnotherService(AnotherService $anotherService): void
+    {
+        $this->anotherService = $anotherService;
+    }
+
+    public function getAnotherService(): AnotherService
+    {
+        return $this->anotherService;
+    }
+}
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Fixture;
+
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\AnotherService;
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\YetAnotherService;
+
+class BaseServiceWithConstructor
+{
+    protected YetAnotherService $baseDep;
+
+    public function __construct(YetAnotherService $baseDep)
+    {
+        $this->baseDep = $baseDep;
+    }
+}
+
+class SkipIfConstructorInParentClass extends BaseServiceWithConstructor
+{
+    private AnotherService $anotherService;
+
+    // This inject method should not be processed because BaseServiceWithConstructor has a constructor
+    public function injectAnotherService(AnotherService $anotherService): void
+    {
+        $this->anotherService = $anotherService;
+    }
+
+    public function getAnotherService(): AnotherService
+    {
+        return $this->anotherService;
+    }
+}
+?>

--- a/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Fixture/skip_if_constructor_in_same_class.php.inc
+++ b/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Fixture/skip_if_constructor_in_same_class.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Fixture;
+
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\MyService;
+
+class SkipIfConstructorInSameClass
+{
+    private MyService $myService;
+    private bool $isInitialized;
+
+    public function __construct()
+    {
+        $this->isInitialized = true;
+    }
+
+    public function injectMyService(MyService $myService): void
+    {
+        $this->myService = $myService;
+    }
+
+    public function getServiceStatus(): bool
+    {
+        return isset($this->myService) && $this->isInitialized;
+    }
+}
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Fixture;
+
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\MyService;
+
+class SkipIfConstructorInSameClass
+{
+    private MyService $myService;
+    private bool $isInitialized;
+
+    public function __construct()
+    {
+        $this->isInitialized = true;
+    }
+
+    public function injectMyService(MyService $myService): void
+    {
+        $this->myService = $myService;
+    }
+
+    public function getServiceStatus(): bool
+    {
+        return isset($this->myService) && $this->isInitialized;
+    }
+}
+?>

--- a/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Source/AnotherService.php
+++ b/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Source/AnotherService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source;
+
+final class AnotherService
+{
+}

--- a/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Source/MyService.php
+++ b/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Source/MyService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source;
+
+final class MyService
+{
+}

--- a/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Source/YetAnotherService.php
+++ b/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Source/YetAnotherService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source;
+
+final class YetAnotherService
+{
+}


### PR DESCRIPTION
Resolves: #4457