### PR TITLE
[BUGFIX] Skip InjectMethodToConstructorInjectionRector for abstract classes

### DIFF
--- a/rules/CodeQuality/General/InjectMethodToConstructorInjectionRector.php
+++ b/rules/CodeQuality/General/InjectMethodToConstructorInjectionRector.php
@@ -158,6 +158,10 @@ CODE_SAMPLE
 
     private function shouldSkip(Class_ $classNode): bool
     {
+        if ($classNode->isAbstract()) {
+            return true;
+        }
+
         $className = $this->getName($classNode);
 
         // Handle anonymous classes: they don't have "parents" in the same way for reflection

--- a/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Fixture/skip_if_abstract_class.php.inc
+++ b/tests/Rector/CodeQuality/General/InjectMethodToConstructorInjectionRector/Fixture/skip_if_abstract_class.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Fixture;
+
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\MyService;
+
+abstract class SkipIfAbstractClass
+{
+    private MyService $myService;
+
+    public function injectMyService(MyService $myService): void
+    {
+        $this->myService = $myService;
+    }
+}
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Fixture;
+
+use Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector\Source\MyService;
+
+abstract class SkipIfAbstractClass
+{
+    private MyService $myService;
+
+    public function injectMyService(MyService $myService): void
+    {
+        $this->myService = $myService;
+    }
+}
+?>


### PR DESCRIPTION
In abstract classes method injection should be preferred over constructor injection (see https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/DependencyInjection/Index.html#method-injection)