### PR TITLE
[TASK] Insert TODO comment to stay consistent with other rules

### DIFF
--- a/rules/TYPO312/v0/MigrateFileFieldTCAConfigToTCATypeFileRector.php
+++ b/rules/TYPO312/v0/MigrateFileFieldTCAConfigToTCATypeFileRector.php
@@ -113,7 +113,7 @@ CODE_SAMPLE
 
         $fileFieldTCAConfigArray = new Array_();
         $fileFieldTCAConfigArray->items[] = new ArrayItem(new String_('file'), new String_('type'), false, [
-            AttributeKey::COMMENTS => [new Comment('### !!! Watch out for fieldName different from columnName')],
+            AttributeKey::COMMENTS => [new Comment('// TODO: Important! Verify that fieldName in foreign table matches columnName (see https://docs.typo3.org/permalink/t3tca:confval-inline-foreign-match-fields)')],
         ]);
 
         if (isset($node->args[2])) {

--- a/tests/Rector/v12/v0/MigrateFileFieldTCAConfigToTCATypeFileRector/Fixture/tca.php.inc
+++ b/tests/Rector/v12/v0/MigrateFileFieldTCAConfigToTCATypeFileRector/Fixture/tca.php.inc
@@ -54,7 +54,7 @@ return [
             'exclude' => false,
             'label' => 'Label',
             'config' => [
-                ### !!! Watch out for fieldName different from columnName
+                // TODO: Important! Verify that fieldName in foreign table matches columnName (see https://docs.typo3.org/permalink/t3tca:confval-inline-foreign-match-fields)
                 'type' => 'file',
                 'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
                 'maxitems' => 1,


### PR DESCRIPTION
Other rector rules already use `TODO` to annotate manual tasks that need to be done after the rector process. This has the advantage that these will be highlighted and/or listed by supporting IDEs.