### PR TITLE
[FEATURE] Add rule to automatically add TCA default values

### DIFF
--- a/config/v13/tca-134.php
+++ b/config/v13/tca-134.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\TYPO313\v4\TcaDefaultsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+    $rectorConfig->rule(TcaDefaultsRector::class);
+};

--- a/rules/TYPO313/v4/TcaDefaultsRector.php
+++ b/rules/TYPO313/v4/TcaDefaultsRector.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\TYPO313\v4;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
+use Ssch\TYPO3Rector\Contract\NoChangelogRequiredInterface;
+use Ssch\TYPO3Rector\Rector\AbstractTcaRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\TcaDefaultsRectorTest
+ */
+final class TcaDefaultsRector extends AbstractTcaRector implements DocumentedRuleInterface, NoChangelogRequiredInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add a default value to TCA fields if missing', [new CodeSample(
+            <<<'CODE_SAMPLE'
+return [
+    'columns' => [
+        'nullable_column' => [
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+return [
+    'columns' => [
+        'nullable_column' => [
+            'config' => [
+                'type' => 'input',
+                'default' => '',
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE
+        )]);
+    }
+
+    protected function refactorColumn(Expr $columnName, Expr $columnTca): void
+    {
+        $configArray = $this->extractSubArrayByKey($columnTca, self::CONFIG);
+        if (! $configArray instanceof Array_) {
+            return;
+        }
+
+        if ($this->hasKey($configArray, 'default')) {
+            return;
+        }
+
+        if ($this->hasKeyValuePair($configArray, 'nullable', true)) {
+            $configArray->items[] = new ArrayItem(new ConstFetch(new Name('null')), new String_('default'));
+            $this->hasAstBeenChanged = true;
+            return;
+        }
+
+        if ($this->isConfigType($configArray, 'input')
+            || $this->isConfigType($configArray, 'color')
+            || $this->isConfigType($configArray, 'email')
+            || $this->isConfigType($configArray, 'link')
+            || $this->isConfigType($configArray, 'password')
+            || $this->isConfigType($configArray, 'slug')
+            || $this->isConfigType($configArray, 'text')
+        ) {
+            $configArray->items[] = new ArrayItem(new String_(''), new String_('default'));
+            $this->hasAstBeenChanged = true;
+            return;
+        }
+
+        if ($this->isConfigType($configArray, 'number')
+            || $this->isConfigType($configArray, 'datetime')
+            || $this->isConfigType($configArray, 'check')
+            || $this->isConfigType($configArray, 'radio')
+            || $this->isConfigType($configArray, 'inline')
+            || $this->isConfigType($configArray, 'select')
+            || $this->isConfigType($configArray, 'group')
+        ) {
+            $configArray->items[] = new ArrayItem(new Int_(0), new String_('default'));
+            $this->hasAstBeenChanged = true;
+        }
+    }
+}

--- a/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+    ],
+];
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'input', 'default' => '',
+            ],
+        ],
+    ],
+];
+?>

--- a/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_datetime_nullable.php.inc
+++ b/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_datetime_nullable.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'datetime',
+                'nullable' => true,
+            ],
+        ],
+    ],
+];
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'datetime',
+                'nullable' => true,
+                'default' => null,
+            ],
+        ],
+    ],
+];
+?>

--- a/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_number.php.inc
+++ b/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_number.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'number',
+            ],
+        ],
+    ],
+];
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'number', 'default' => 0,
+            ],
+        ],
+    ],
+];
+?>

--- a/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_number_default.php.inc
+++ b/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_number_default.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'number',
+                'default' => 42,
+            ],
+        ],
+    ],
+];
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'number',
+                'default' => 42,
+            ],
+        ],
+    ],
+];
+?>

--- a/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_select.php.inc
+++ b/tests/Rector/v13/v4/TcaDefaultsRector/Fixture/fixture_select.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'select',
+            ]
+        ],
+    ],
+];
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'select', 'default' => 0,
+            ]
+        ],
+    ],
+];
+?>

--- a/tests/Rector/v13/v4/TcaDefaultsRector/TcaDefaultsRectorTest.php
+++ b/tests/Rector/v13/v4/TcaDefaultsRector/TcaDefaultsRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\TcaDefaultsRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TcaDefaultsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<array<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/v13/v4/TcaDefaultsRector/config/configured_rule.php
+++ b/tests/Rector/v13/v4/TcaDefaultsRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\TYPO313\v4\TcaDefaultsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config_test.php');
+    $rectorConfig->rule(TcaDefaultsRector::class);
+};


### PR DESCRIPTION
With TYPO3 13 the ext_tables.sql file is not mandatory anymore.
When removing the ext_tables.sql TCA fields without a default value can
cause errors when thawing Extbase model objects

(Fallback chaing default value of the model property -> TCA default value -> ext_tables.sql default value). Having a default value for all TCA fields that are likely mapped to models can prevent errors on thawing.

* Existing default values are preserved.

* If the field is nullable, the default value is null

* For string fields (input, color, email, text, ...) the default is an empty string

* For numeral fields (number, select, group, ...) the default is zero