### PR TITLE
[BUGFIX] Use different filesystems depending on the context

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -2,16 +2,13 @@
 
 declare(strict_types=1);
 
-use League\Flysystem\Filesystem;
-use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
-use League\Flysystem\Local\LocalFilesystemAdapter;
 use Rector\Config\RectorConfig;
-use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\Contract\FilesystemInterface;
+use Ssch\TYPO3Rector\Contract\LocalFilesystemInterface;
 use Ssch\TYPO3Rector\Filesystem\FileInfoFactory;
 use Ssch\TYPO3Rector\Filesystem\FilesFinder;
-use Ssch\TYPO3Rector\Filesystem\FlysystemFilesystem;
+use Ssch\TYPO3Rector\Filesystem\FilesystemFactory;
 use Ssch\TYPO3Rector\NodeAnalyzer\ExtbaseControllerRedirectAnalyzer;
 use Ssch\TYPO3Rector\NodeFactory\InjectMethodFactory;
 use Ssch\TYPO3Rector\NodeFactory\Typo3GlobalsFactory;
@@ -25,15 +22,16 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(InjectMethodFactory::class);
     $rectorConfig->singleton(Typo3GlobalsFactory::class);
     $rectorConfig->singleton(Typo3NodeResolver::class);
-    $rectorConfig->bind(FilesystemInterface::class, static function () {
-        $argv = $_SERVER['argv'] ?? [];
-        $isDryRun = in_array('--dry-run', $argv, true) || in_array('-n', $argv, true);
-        if ($isDryRun || StaticPHPUnitEnvironment::isPHPUnitRun()) {
-            $adapter = new InMemoryFilesystemAdapter();
-        } else {
-            $adapter = new LocalFilesystemAdapter('/');
-        }
 
-        return new FlysystemFilesystem(new Filesystem($adapter));
-    });
+    $rectorConfig->singleton(FilesystemFactory::class, fn () => new FilesystemFactory('/'));
+    // This filesystem is used for reading files
+    $rectorConfig->bind(
+        LocalFilesystemInterface::class,
+        static fn (RectorConfig $app) => $app->make(FilesystemFactory::class)->createLocalFilesystem()
+    );
+    // This filesystem is used for writing files
+    $rectorConfig->bind(
+        FilesystemInterface::class,
+        static fn (RectorConfig $app) => $app->make(FilesystemFactory::class)->create()
+    );
 };

--- a/src/ComposerExtensionKeyResolver.php
+++ b/src/ComposerExtensionKeyResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector;
 
 use Rector\ValueObject\Application\File;
-use Ssch\TYPO3Rector\Contract\FilesystemInterface;
+use Ssch\TYPO3Rector\Contract\LocalFilesystemInterface;
 use Ssch\TYPO3Rector\Filesystem\FilesFinder;
 
 final class ComposerExtensionKeyResolver
@@ -13,14 +13,14 @@ final class ComposerExtensionKeyResolver
     /**
      * @readonly
      */
-    private FilesystemInterface $filesystem;
+    private LocalFilesystemInterface $filesystem;
 
     /**
      * @readonly
      */
     private FilesFinder $filesFinder;
 
-    public function __construct(FilesystemInterface $filesystem, FilesFinder $filesFinder)
+    public function __construct(LocalFilesystemInterface $filesystem, FilesFinder $filesFinder)
     {
         $this->filesystem = $filesystem;
         $this->filesFinder = $filesFinder;

--- a/src/ComposerPsr4Resolver.php
+++ b/src/ComposerPsr4Resolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector;
 
 use Rector\ValueObject\Application\File;
-use Ssch\TYPO3Rector\Contract\FilesystemInterface;
+use Ssch\TYPO3Rector\Contract\LocalFilesystemInterface;
 use Ssch\TYPO3Rector\Filesystem\FilesFinder;
 
 final class ComposerPsr4Resolver
@@ -13,14 +13,14 @@ final class ComposerPsr4Resolver
     /**
      * @readonly
      */
-    private FilesystemInterface $filesystem;
+    private LocalFilesystemInterface $filesystem;
 
     /**
      * @readonly
      */
     private FilesFinder $filesFinder;
 
-    public function __construct(FilesystemInterface $filesystem, FilesFinder $filesFinder)
+    public function __construct(LocalFilesystemInterface $filesystem, FilesFinder $filesFinder)
     {
         $this->filesystem = $filesystem;
         $this->filesFinder = $filesFinder;

--- a/src/Contract/LocalFilesystemInterface.php
+++ b/src/Contract/LocalFilesystemInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Contract;
+
+interface LocalFilesystemInterface extends FilesystemInterface
+{
+}

--- a/src/Filesystem/FilesystemFactory.php
+++ b/src/Filesystem/FilesystemFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Filesystem;
+
+use League\Flysystem\Filesystem;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
+use Ssch\TYPO3Rector\Contract\FilesystemInterface;
+
+final class FilesystemFactory
+{
+    private string $projectDir;
+
+    public function __construct(string $projectDir)
+    {
+        $this->projectDir = $projectDir;
+    }
+
+    public function create(): FilesystemInterface
+    {
+        $argv = $_SERVER['argv'] ?? [];
+        $isDryRun = in_array('--dry-run', $argv, true) || in_array('-n', $argv, true);
+
+        if ($isDryRun || StaticPHPUnitEnvironment::isPHPUnitRun()) {
+            $adapter = new InMemoryFilesystemAdapter();
+        } else {
+            $adapter = new LocalFilesystemAdapter($this->projectDir);
+        }
+
+        return new FlysystemFilesystem(new Filesystem($adapter));
+    }
+
+    public function createLocalFilesystem(): FilesystemInterface
+    {
+        if (StaticPHPUnitEnvironment::isPHPUnitRun()) {
+            $adapter = new InMemoryFilesystemAdapter();
+        } else {
+            $adapter = new LocalFilesystemAdapter($this->projectDir);
+        }
+
+        return new FlysystemFilesystem(new Filesystem($adapter));
+    }
+}

--- a/src/Filesystem/FlysystemFilesystem.php
+++ b/src/Filesystem/FlysystemFilesystem.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector\Filesystem;
 
 use League\Flysystem\FilesystemOperator;
-use Ssch\TYPO3Rector\Contract\FilesystemInterface;
+use Ssch\TYPO3Rector\Contract\LocalFilesystemInterface;
 
-final class FlysystemFilesystem implements FilesystemInterface
+final class FlysystemFilesystem implements LocalFilesystemInterface
 {
     /**
      * @readonly

--- a/tests/Rector/v13/v4/MigratePluginContentElementAndPluginSubtypesRector/MigratePluginContentElementAndPluginSubtypesRectorTest.php
+++ b/tests/Rector/v13/v4/MigratePluginContentElementAndPluginSubtypesRector/MigratePluginContentElementAndPluginSubtypesRectorTest.php
@@ -6,10 +6,13 @@ namespace Ssch\TYPO3Rector\Tests\Rector\v13\v4\MigratePluginContentElementAndPlu
 
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Ssch\TYPO3Rector\Contract\FilesystemInterface;
+use Ssch\TYPO3Rector\Contract\LocalFilesystemInterface;
 
 final class MigratePluginContentElementAndPluginSubtypesRectorTest extends AbstractRectorTestCase
 {
     private FilesystemInterface $filesystem;
+
+    private LocalFilesystemInterface $localFilesystem;
 
     /**
      * @var string[]
@@ -19,7 +22,7 @@ final class MigratePluginContentElementAndPluginSubtypesRectorTest extends Abstr
     protected function setUp(): void
     {
         parent::setUp();
-        $this->initializeFilesystem();
+        $this->initializeFilesystems();
     }
 
     protected function tearDown(): void
@@ -42,7 +45,7 @@ final class MigratePluginContentElementAndPluginSubtypesRectorTest extends Abstr
         // Arrange
         $composerJson = __DIR__ . '/Fixture/' . $extensionKey . '/composer.json';
         $this->testFilesToDelete[] = $composerJson;
-        $this->filesystem->write($composerJson, '{
+        $this->localFilesystem->write($composerJson, '{
     "name": "typo3/rector",
     "description": "TYPO3 Rector Test Extension",
     "autoload": {
@@ -111,9 +114,9 @@ final class MigratePluginContentElementAndPluginSubtypesRectorTest extends Abstr
         return __DIR__ . '/config/configured_rule.php';
     }
 
-    private function initializeFilesystem(): void
+    private function initializeFilesystems(): void
     {
-        $this->filesystem = self::getContainer()
-            ->get(FilesystemInterface::class);
+        $this->filesystem = self::getContainer()->get(FilesystemInterface::class);
+        $this->localFilesystem = self::getContainer()->get(LocalFilesystemInterface::class);
     }
 }


### PR DESCRIPTION
When running dry-mode, the files from disk must be read instead of the memory. This makes sure that files are not actually written. In unit tests read operations must use a different filesystem than the write operations.