### PR TITLE
[FEATURE] Add MigrateFlexFormParsingHooksToEventListenersRector

### DIFF
--- a/config/v12/typo3-120.php
+++ b/config/v12/typo3-120.php
@@ -16,6 +16,7 @@ use Ssch\TYPO3Rector\TYPO312\v0\MigrateContentObjectRendererLastTypoLinkProperti
 use Ssch\TYPO3Rector\TYPO312\v0\MigrateFetchAllToFetchAllAssociativeRector;
 use Ssch\TYPO3Rector\TYPO312\v0\MigrateFetchColumnToFetchOneRector;
 use Ssch\TYPO3Rector\TYPO312\v0\MigrateFetchToFetchAssociativeRector;
+use Ssch\TYPO3Rector\TYPO312\v0\MigrateFlexFormParsingHooksToEventListenersRector;
 use Ssch\TYPO3Rector\TYPO312\v0\MigrateGetControllerContextGetUriBuilderRector;
 use Ssch\TYPO3Rector\TYPO312\v0\MigrateQueryBuilderExecuteRector;
 use Ssch\TYPO3Rector\TYPO312\v0\MoveAllowTableOnStandardPagesToTCAConfigurationRector;
@@ -179,4 +180,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(RemoveAddLLrefForTCAdescrMethodCallRector::class);
     $rectorConfig->rule(MigrateGetControllerContextGetUriBuilderRector::class);
     $rectorConfig->rule(UseLanguageAspectInExtbasePersistenceRector::class);
+    $rectorConfig->rule(MigrateFlexFormParsingHooksToEventListenersRector::class);
 };

--- a/rules/TYPO312/v0/MigrateFlexFormParsingHooksToEventListenersRector.php
+++ b/rules/TYPO312/v0/MigrateFlexFormParsingHooksToEventListenersRector.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\TYPO312\v0;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
+ * @see \Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\MigrateFlexFormParsingHooksToEventListenersRectorTest
+ */
+final class MigrateFlexFormParsingHooksToEventListenersRector extends AbstractRector implements DocumentedRuleInterface
+{
+    /**
+     * @var array<string, array{eventClass: string, methodName: string}>
+     */
+    private const METHOD_TO_EVENT_MAP = [
+        'parseDataStructureByIdentifierPreProcess' => [
+            'eventClass' => 'TYPO3\\CMS\\Core\\Configuration\\Event\\BeforeFlexFormDataStructureParsedEvent',
+            'methodName' => 'handleBeforeFlexFormDataStructureParsed',
+        ],
+        'parseDataStructureByIdentifierPostProcess' => [
+            'eventClass' => 'TYPO3\\CMS\\Core\\Configuration\\Event\\AfterFlexFormDataStructureParsedEvent',
+            'methodName' => 'handleAfterFlexFormDataStructureParsed',
+        ],
+        'getDataStructureIdentifierPreProcess' => [
+            'eventClass' => 'TYPO3\\CMS\\Core\\Configuration\\Event\\BeforeFlexFormDataStructureIdentifierInitializedEvent',
+            'methodName' => 'handleBeforeFlexFormDataStructureIdentifierInitialized',
+        ],
+        'getDataStructureIdentifierPostProcess' => [
+            'eventClass' => 'TYPO3\\CMS\\Core\\Configuration\\Event\\AfterFlexFormDataStructureIdentifierInitializedEvent',
+            'methodName' => 'handleAfterFlexFormDataStructureIdentifierInitialized',
+        ],
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Migrate FlexForm parsing hooks to PSR-14 event listeners',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class MyFlexFormHook
+{
+    public function parseDataStructureByIdentifierPreProcess(array $identifier): array
+    {
+        if ($identifier['type'] === 'my_type') {
+            return ['ROOT' => []];
+        }
+        return [];
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use TYPO3\CMS\Core\Configuration\Event\BeforeFlexFormDataStructureParsedEvent;
+
+class MyFlexFormHook
+{
+    /**
+     * @todo Register this listener in Configuration/Services.yaml. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
+     */
+    public function handleBeforeFlexFormDataStructureParsed(BeforeFlexFormDataStructureParsedEvent $event): void
+    {
+        if ($identifier['type'] === 'my_type') {
+            return ['ROOT' => []];
+        }
+        return [];
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $hasChanged = false;
+
+        foreach (self::METHOD_TO_EVENT_MAP as $oldMethodName => $config) {
+            $method = $node->getMethod($oldMethodName);
+            if (! $method instanceof ClassMethod) {
+                continue;
+            }
+
+            $this->migrateMethod($method, $config['eventClass'], $config['methodName']);
+            $hasChanged = true;
+        }
+
+        return $hasChanged ? $node : null;
+    }
+
+    private function migrateMethod(ClassMethod $method, string $eventClass, string $newMethodName): void
+    {
+        // Rename the method
+        $method->name = new Identifier($newMethodName);
+
+        // Change return type to void
+        $method->returnType = new Identifier('void');
+
+        // Replace all parameters with single event parameter
+        $method->params = [new Param(new Variable('event'), null, new FullyQualified($eventClass))];
+
+        // Add docblock with todo
+        $docComment = <<<'DOC'
+/**
+     * @todo Register this listener in Configuration/Services.yaml. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
+     */
+DOC;
+        $method->setDocComment(new \PhpParser\Comment\Doc($docComment));
+    }
+}

--- a/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/get_identifier_post_process.php.inc
+++ b/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/get_identifier_post_process.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+class MyIdentifierPostHook
+{
+    public function getDataStructureIdentifierPostProcess(array $fieldTca, string $tableName, string $fieldName, array $row, array $identifier): array
+    {
+        $identifier['type'] = 'modified_type';
+        return $identifier;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+use TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureIdentifierInitializedEvent;
+
+class MyIdentifierPostHook
+{
+    /**
+     * @todo Register this listener in Configuration/Services.yaml. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
+     */
+    public function handleAfterFlexFormDataStructureIdentifierInitialized(AfterFlexFormDataStructureIdentifierInitializedEvent $event): void
+    {
+        $identifier['type'] = 'modified_type';
+        return $identifier;
+    }
+}
+
+?>

--- a/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/get_identifier_pre_process.php.inc
+++ b/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/get_identifier_pre_process.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+class MyIdentifierPreHook
+{
+    public function getDataStructureIdentifierPreProcess(array $fieldTca, string $tableName, string $fieldName, array $row): array
+    {
+        if ($tableName === 'tx_myext_sometable') {
+            return ['type' => 'my_custom_type'];
+        }
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+use TYPO3\CMS\Core\Configuration\Event\BeforeFlexFormDataStructureIdentifierInitializedEvent;
+
+class MyIdentifierPreHook
+{
+    /**
+     * @todo Register this listener in Configuration/Services.yaml. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
+     */
+    public function handleBeforeFlexFormDataStructureIdentifierInitialized(BeforeFlexFormDataStructureIdentifierInitializedEvent $event): void
+    {
+        if ($tableName === 'tx_myext_sometable') {
+            return ['type' => 'my_custom_type'];
+        }
+        return [];
+    }
+}
+
+?>

--- a/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/parse_data_structure_post_process.php.inc
+++ b/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/parse_data_structure_post_process.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+class MyFlexFormPostHook
+{
+    public function parseDataStructureByIdentifierPostProcess(array $identifier, array $dataStructure): array
+    {
+        $dataStructure['sheets']['sDEF']['ROOT']['TCEforms']['sheetTitle'] = 'Modified';
+        return $dataStructure;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+use TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureParsedEvent;
+
+class MyFlexFormPostHook
+{
+    /**
+     * @todo Register this listener in Configuration/Services.yaml. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
+     */
+    public function handleAfterFlexFormDataStructureParsed(AfterFlexFormDataStructureParsedEvent $event): void
+    {
+        $dataStructure['sheets']['sDEF']['ROOT']['TCEforms']['sheetTitle'] = 'Modified';
+        return $dataStructure;
+    }
+}
+
+?>

--- a/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/parse_data_structure_pre_process.php.inc
+++ b/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/Fixture/parse_data_structure_pre_process.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+class MyFlexFormHook
+{
+    public function parseDataStructureByIdentifierPreProcess(array $identifier): array
+    {
+        if ($identifier['type'] === 'my_type') {
+            return ['ROOT' => []];
+        }
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector\Fixture;
+
+use TYPO3\CMS\Core\Configuration\Event\BeforeFlexFormDataStructureParsedEvent;
+
+class MyFlexFormHook
+{
+    /**
+     * @todo Register this listener in Configuration/Services.yaml. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
+     */
+    public function handleBeforeFlexFormDataStructureParsed(BeforeFlexFormDataStructureParsedEvent $event): void
+    {
+        if ($identifier['type'] === 'my_type') {
+            return ['ROOT' => []];
+        }
+        return [];
+    }
+}
+
+?>

--- a/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/MigrateFlexFormParsingHooksToEventListenersRectorTest.php
+++ b/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/MigrateFlexFormParsingHooksToEventListenersRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v0\MigrateFlexFormParsingHooksToEventListenersRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MigrateFlexFormParsingHooksToEventListenersRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<array<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/config/configured_rule.php
+++ b/tests/Rector/v12/v0/MigrateFlexFormParsingHooksToEventListenersRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\TYPO312\v0\MigrateFlexFormParsingHooksToEventListenersRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config_test.php');
+    $rectorConfig->rule(MigrateFlexFormParsingHooksToEventListenersRector::class);
+};


### PR DESCRIPTION
Migrates FlexForm parsing hooks to PSR-14 event listeners:
- parseDataStructureByIdentifierPreProcess -> BeforeFlexFormDataStructureParsedEvent
- parseDataStructureByIdentifierPostProcess -> AfterFlexFormDataStructureParsedEvent
- getDataStructureIdentifierPreProcess -> BeforeFlexFormDataStructureIdentifierInitializedEvent
- getDataStructureIdentifierPostProcess -> AfterFlexFormDataStructureIdentifierInitializedEvent

See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html