### PR TITLE
[TASK] Deactivate AddAutoconfigureAttributeToClassRector

### DIFF
--- a/config/code-quality.php
+++ b/config/code-quality.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Ssch\TYPO3Rector\CodeQuality\General\AddAutoconfigureAttributeToClassRector;
 use Ssch\TYPO3Rector\CodeQuality\General\AddErrorCodeToExceptionRector;
 use Ssch\TYPO3Rector\CodeQuality\General\ConvertImplicitVariablesToExplicitGlobalsRector;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
@@ -153,6 +152,7 @@ return static function (RectorConfig $rectorConfig): void {
         ],
     ]);
     // $rectorConfig->rule(RemoveTypo3VersionChecksRector::class); this rule is not activated by default as it depends on the (configured) TYPO3 version!
+    // $rectorConfig->rule(AddAutoconfigureAttributeToClassRector::class); This rule does way too much atm. Deactivate for now.
     $rectorConfig->rule(AddErrorCodeToExceptionRector::class);
     $rectorConfig->rule(ConvertImplicitVariablesToExplicitGlobalsRector::class);
     $rectorConfig->rule(InjectMethodToConstructorInjectionRector::class);
@@ -160,5 +160,4 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector::class);
     $rectorConfig->rule(MoveExtensionUtilityRegisterPluginIntoTCAOverridesRector::class);
     $rectorConfig->rule(UseExtensionKeyInLocalizationUtilityRector::class);
-    $rectorConfig->rule(AddAutoconfigureAttributeToClassRector::class);
 };


### PR DESCRIPTION
This rule adds way too many annotations. Deactivate it for now until it only does what it should do: Add only the annotations which are defined in the Services.yaml