### PR TITLE
[FEATURE] Migrate fluid classnames to standalone fluid

### DIFF
--- a/config/typo3-10.php
+++ b/config/typo3-10.php
@@ -12,5 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/v10/typo3-102.php');
     $rectorConfig->import(__DIR__ . '/v10/typo3-103.php');
     $rectorConfig->import(__DIR__ . '/v10/typo3-104.php');
+    $rectorConfig->import(__DIR__ . '/v10/rename-classes.php');
     $rectorConfig->import(__DIR__ . '/v10/use-constants-from-typo3-database-connection.php');
 };

--- a/config/v10/rename-classes.php
+++ b/config/v10/rename-classes.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(RenameClassRector::class, [
+            // Deprecation: #87277 - Fluid Class Aliases
+            // https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5.x/Deprecation-87277-FluidClassAliases.html
+            'TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper' => 'TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper' => 'TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper' => 'TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper',
+            'TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler' => 'TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler',
+            'TYPO3\CMS\Fluid\Core\Parser\InterceptorInterface' => 'TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface',
+            'TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\AbstractNode' => 'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode',
+            'TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\NodeInterface' => 'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface',
+            'TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\RootNode' => 'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode',
+            'TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode' => 'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode',
+            'TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface' => 'TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperInterface' => 'TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface' => 'TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface' => 'TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\Facets\PostParseInterface' => 'TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface',
+            'TYPO3\CMS\Fluid\Core\Exception' => 'TYPO3Fluid\Fluid\Core\Exception',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\Exception' => 'TYPO3Fluid\Fluid\Core\ViewHelper\Exception',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException' => 'TYPO3Fluid\Fluid\Core\Exception',
+            'TYPO3\CMS\Fluid\View\Exception' => 'TYPO3Fluid\Fluid\View\Exception',
+            'TYPO3\CMS\Fluid\View\Exception\InvalidSectionException' => 'TYPO3Fluid\Fluid\View\Exception\InvalidSectionException',
+            'TYPO3\CMS\Fluid\View\Exception\InvalidTemplateResourceException' => 'TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\ArgumentDefinition' => 'TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\TemplateVariableContainer' => 'TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperVariableContainer' => 'TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer',
+            'TYPO3\CMS\Fluid\Core\Variables\CmsVariableProvider' => 'TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder' => 'TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder',
+            'TYPO3\CMS\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic' => 'TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic',
+        ]);
+};

--- a/tests/Rector/v10/v0/MigrateFluidClassAliasesRector/Fixture/fixture.php.inc
+++ b/tests/Rector/v10/v0/MigrateFluidClassAliasesRector/Fixture/fixture.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v10\v0\MigrateFluidClassAliasesRector\Fixture;
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
+
+class MyViewHelper extends AbstractTagBasedViewHelper implements CompilableInterface
+{
+    public function render(): string
+    {
+        try {
+            return 'output';
+        } catch (Exception $e) {
+            return '';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v10\v0\MigrateFluidClassAliasesRector\Fixture;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+
+class MyViewHelper extends AbstractTagBasedViewHelper implements ViewHelperInterface
+{
+    public function render(): string
+    {
+        try {
+            return 'output';
+        } catch (Exception $e) {
+            return '';
+        }
+    }
+}
+
+?>

--- a/tests/Rector/v10/v0/MigrateFluidClassAliasesRector/MigrateFluidClassAliasesRectorTest.php
+++ b/tests/Rector/v10/v0/MigrateFluidClassAliasesRector/MigrateFluidClassAliasesRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v10\v0\MigrateFluidClassAliasesRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MigrateFluidClassAliasesRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<array<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/v10/v0/MigrateFluidClassAliasesRector/config/configured_rule.php
+++ b/tests/Rector/v10/v0/MigrateFluidClassAliasesRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config_test.php');
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/v10/rename-classes.php');
+};


### PR DESCRIPTION
Just migrated a project from 9 to 13 and noticed that those fluid classname migrations were missing. So I implemented a rector for them. Then I noticed they we're covered once (#1320) but got removed when creating version 2. I'd like to have them back, for version 2 should be covering upgrades to version 10, no?

* Deprecated in v9: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5.x/Deprecation-87277-FluidClassAliases.html
* Breaking change in v10: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html

This effectively brings back feature #1320 that got removed with version 2.0.

Related: #1202