### PR TITLE
[BUGFIX] Migration not covering all cases of $GLOBALS['TSFE']->fe_user

### DIFF
--- a/rules/TYPO313/v0/MigrateTypoScriptFrontendControllerFeUserRector.php
+++ b/rules/TYPO313/v0/MigrateTypoScriptFrontendControllerFeUserRector.php
@@ -114,15 +114,22 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $readExpression = $this->getReadExpression($node);
-        if (! $readExpression instanceof PropertyFetch || ! $this->isFeUserPropertyFetch($readExpression)) {
-            return null;
+        if ($readExpression instanceof PropertyFetch && $this->isFeUserPropertyFetch($readExpression)) {
+            $replacement = $this->createReplacement($readExpression);
+            $this->replaceReadExpression($node, $replacement);
+
+            return $node;
         }
 
-        $replacement = $this->createReplacement($readExpression);
+        // Handle standalone $GLOBALS['TSFE']->fe_user (e.g. in return statements or conditions)
+        if ($node instanceof PropertyFetch
+            && ! $node->getAttribute(AttributeKey::IS_BEING_ASSIGNED)
+            && $this->isFeUserPropertyFetch($node)
+        ) {
+            return $this->createReplacement($node);
+        }
 
-        $this->replaceReadExpression($node, $replacement);
-
-        return $node;
+        return null;
     }
 
     private function getReadExpression(Node $node): ?Expr

--- a/tests/Rector/v13/v0/MigrateTypoScriptFrontendControllerFeUserRector/Fixture/standalone.php.inc
+++ b/tests/Rector/v13/v0/MigrateTypoScriptFrontendControllerFeUserRector/Fixture/standalone.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v0\MigrateTypoScriptFrontendControllerFeUserRector\Fixture;
+
+class Standalone
+{
+    public function returnFeUser()
+    {
+        return $GLOBALS['TSFE']->fe_user;
+    }
+
+    public function conditionFeUser(): void
+    {
+        if ($GLOBALS['TSFE']->fe_user) {
+            echo 'has user';
+        }
+    }
+
+    public function argumentFeUser(): void
+    {
+        $this->doSomething($GLOBALS['TSFE']->fe_user);
+    }
+
+    private function doSomething($user): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v0\MigrateTypoScriptFrontendControllerFeUserRector\Fixture;
+
+class Standalone
+{
+    public function returnFeUser()
+    {
+        return $GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.user');
+    }
+
+    public function conditionFeUser(): void
+    {
+        if ($GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.user')) {
+            echo 'has user';
+        }
+    }
+
+    public function argumentFeUser(): void
+    {
+        $this->doSomething($GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.user'));
+    }
+
+    private function doSomething($user): void
+    {
+    }
+}
+?>

--- a/tests/Rector/v13/v0/MigrateTypoScriptFrontendControllerFeUserRector/Fixture/standalone_extbase.php.inc
+++ b/tests/Rector/v13/v0/MigrateTypoScriptFrontendControllerFeUserRector/Fixture/standalone_extbase.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v0\MigrateTypoScriptFrontendControllerFeUserRector\Fixture;
+
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class StandaloneExtbase extends ActionController
+{
+    public function returnFeUser()
+    {
+        return $GLOBALS['TSFE']->fe_user;
+    }
+
+    public function conditionFeUser(): void
+    {
+        if ($GLOBALS['TSFE']->fe_user) {
+            echo 'has user';
+        }
+    }
+}
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v0\MigrateTypoScriptFrontendControllerFeUserRector\Fixture;
+
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class StandaloneExtbase extends ActionController
+{
+    public function returnFeUser()
+    {
+        return $this->request->getAttribute('frontend.user');
+    }
+
+    public function conditionFeUser(): void
+    {
+        if ($this->request->getAttribute('frontend.user')) {
+            echo 'has user';
+        }
+    }
+}
+?>


### PR DESCRIPTION
I've noticed that some occurrences of `$GLOBALS['TSFE']->fe_user` we're ignored, like this e.g.

```php
    protected function getFrontendUser()
    {
        if ($GLOBALS['TSFE']->fe_user) {
            return $GLOBALS['TSFE']->fe_user;
        }
    }
```