### PR TITLE
[BUGFIX] Skip HashService calls with an unexpected argument count

### DIFF
--- a/rules/TYPO313/v0/MigrateExtbaseHashServiceToUseCoreHashServiceRector.php
+++ b/rules/TYPO313/v0/MigrateExtbaseHashServiceToUseCoreHashServiceRector.php
@@ -84,17 +84,18 @@ CODE_SAMPLE
             return null;
         }
 
-        if (count($node->args) > 1 && ! $this->isName($node->name, 'validateHmac')) {
-            return null;
-        }
+        // The Extbase signatures are validateHmac($input, $hmac) (2 arguments) and a single $input
+        // argument for the other methods. Skip if the number of arguments does not match.
+        $isValidateHmac = $this->isName($node->name, 'validateHmac');
 
-        if (count($node->args) > 2 && $this->isName($node->name, 'validateHmac')) {
+        $expectedArgumentCount = $isValidateHmac ? 2 : 1;
+        if (count($node->args) !== $expectedArgumentCount) {
             return null;
         }
 
         $additionalSecretArgument = $this->nodeFactory->createArg($this->additionalSecret);
 
-        if ($this->isName($node->name, 'validateHmac')) {
+        if ($isValidateHmac) {
             $node->args[2] = $node->args[1];
             $node->args[1] = $additionalSecretArgument;
         } else {

--- a/tests/Rector/v13/v0/MigrateExtbaseHashServiceToUseCoreHashServiceRector/Fixture/skip_unrelated_validate_hmac_method.php.inc
+++ b/tests/Rector/v13/v0/MigrateExtbaseHashServiceToUseCoreHashServiceRector/Fixture/skip_unrelated_validate_hmac_method.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v0\MigrateExtbaseHashServiceToUseCoreHashServiceRector\Fixture;
+
+class NotAHashService
+{
+    public function caller(string $value): bool
+    {
+        return $this->validateHmac($value);
+    }
+
+    public function validateHmac(string $value): bool
+    {
+        return $value !== '';
+    }
+}

--- a/tests/Rector/v13/v0/MigrateExtbaseHashServiceToUseCoreHashServiceRector/Fixture/skip_validate_hmac_with_unexpected_argument_count.php.inc
+++ b/tests/Rector/v13/v0/MigrateExtbaseHashServiceToUseCoreHashServiceRector/Fixture/skip_validate_hmac_with_unexpected_argument_count.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v0\MigrateExtbaseHashServiceToUseCoreHashServiceRector\Fixture;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
+
+$hashService = GeneralUtility::makeInstance(HashService::class);
+
+$hashService->validateHmac('123');
+
+?>
+-----
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v13\v0\MigrateExtbaseHashServiceToUseCoreHashServiceRector\Fixture;
+
+use TYPO3\CMS\Core\Crypto\HashService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+$hashService = GeneralUtility::makeInstance(HashService::class);
+
+$hashService->validateHmac('123');
+
+?>


### PR DESCRIPTION
The argument count check only rejected calls with more arguments than expected, not fewer. A validateHmac() call with a single argument (instead of the required two) slipped through and hit $node->args[1], which does not exist, causing a crash. 

Replace the two ">" bound checks with a single exact-count check per method (2 for validateHmac(), 1 for the others) and add fixtures covering an unrelated class that happens to declare its own validateHmac() method, and a validateHmac() call with too few arguments.