### PR TITLE
Bump to StructArmed ^0.15 and enable MustBeFinalRule

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -43,7 +43,7 @@ jobs:
             actions:
               name: 'StructArmed'
               run: |
-                composer require --dev boundwize/structarmed:^0.14
+                composer require --dev boundwize/structarmed:^0.15
                 vendor/bin/structarmed analyze
 
     name: "${{ matrix.php-versions }} ${{ matrix.actions.name }}"

--- a/rules/CodeQuality/General/MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRector.php
+++ b/rules/CodeQuality/General/MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRector.php
@@ -25,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://review.typo3.org/c/Packages/TYPO3.CMS/+/52437
  * @see \Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRector\MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRectorTest
  */
-class MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRector extends AbstractRector implements DocumentedRuleInterface
+final class MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRector extends AbstractRector implements DocumentedRuleInterface
 {
     use ExtensionKeyResolverTrait;
 

--- a/rules/CodeQuality/General/MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector.php
+++ b/rules/CodeQuality/General/MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector.php
@@ -24,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://review.typo3.org/c/Packages/TYPO3.CMS/+/52437
  * @see \Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector\MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRectorTest
  */
-class MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector extends AbstractRector implements DocumentedRuleInterface
+final class MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * @readonly

--- a/rules/CodeQuality/General/UseExtensionKeyInLocalizationUtilityRector.php
+++ b/rules/CodeQuality/General/UseExtensionKeyInLocalizationUtilityRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * This rector fixes a common error in TYPO3 installations to use the extension key where the extension name is required
  * @see \Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\UseExtensionKeyInLocalizationUtilityRector\UseExtensionKeyInLocalizationUtilityRectorTest
  */
-class UseExtensionKeyInLocalizationUtilityRector extends AbstractRector implements NoChangelogRequiredInterface, DocumentedRuleInterface
+final class UseExtensionKeyInLocalizationUtilityRector extends AbstractRector implements NoChangelogRequiredInterface, DocumentedRuleInterface
 {
     /**
      * @readonly

--- a/src/PhpParser/Printer/PrettyTypo3Printer.php
+++ b/src/PhpParser/Printer/PrettyTypo3Printer.php
@@ -42,7 +42,7 @@ use Rector\Util\Reflection\PrivatesAccessor;
  *
  * @property array<string, array{string, bool, string, null}> $insertionMap
  */
-class PrettyTypo3Printer extends Standard
+final class PrettyTypo3Printer extends Standard
 {
     /**
      * Remove extra spaces before new Nop_ nodes

--- a/structarmed.php
+++ b/structarmed.php
@@ -4,9 +4,18 @@ declare(strict_types=1);
 
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 return Architecture::define()
+    ->rule(
+        'source.must_be_final',
+        new MustBeFinalRule(layer: 'Source'),
+    )
     ->skip([
         '*/MigratePluginContentElementAndPluginSubtypesRector/Assertions/extension*',
+        'source.must_be_final' => [
+            '*/Source/*',
+            __DIR__ . '/stubs',
+        ],
     ])
     ->withPreset(Preset::PSR4());

--- a/structarmed.php
+++ b/structarmed.php
@@ -15,6 +15,7 @@ return Architecture::define()
         '*/MigratePluginContentElementAndPluginSubtypesRector/Assertions/extension*',
         'source.must_be_final' => [
             '*/Source/*',
+            '*/Sources/*',
             __DIR__ . '/stubs',
         ],
     ])

--- a/tests/Rector/CodeQuality/General/MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRector/MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRectorTest.php
+++ b/tests/Rector/CodeQuality/General/MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRector/MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRectorTest.php
@@ -7,7 +7,7 @@ namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\MoveExtensionManagem
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Ssch\TYPO3Rector\Contract\FilesystemInterface;
 
-class MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRectorTest extends AbstractRectorTestCase
+final class MoveExtensionManagementUtilityAddStaticFileIntoTCAOverridesRectorTest extends AbstractRectorTestCase
 {
     private FilesystemInterface $filesystem;
 

--- a/tests/Rector/CodeQuality/General/MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector/MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRectorTest.php
+++ b/tests/Rector/CodeQuality/General/MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRector/MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRectorTest.php
@@ -7,7 +7,7 @@ namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\MoveExtensionManagem
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Ssch\TYPO3Rector\Contract\FilesystemInterface;
 
-class MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRectorTest extends AbstractRectorTestCase
+final class MoveExtensionManagementUtilityAddToAllTCAtypesIntoTCAOverridesRectorTest extends AbstractRectorTestCase
 {
     private FilesystemInterface $filesystem;
 

--- a/tests/Rector/CodeQuality/General/UseExtensionKeyInLocalizationUtilityRector/UseExtensionKeyInLocalizationUtilityRectorTest.php
+++ b/tests/Rector/CodeQuality/General/UseExtensionKeyInLocalizationUtilityRector/UseExtensionKeyInLocalizationUtilityRectorTest.php
@@ -6,7 +6,7 @@ namespace Ssch\TYPO3Rector\Tests\Rector\CodeQuality\General\UseExtensionKeyInLoc
 
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-class UseExtensionKeyInLocalizationUtilityRectorTest extends AbstractRectorTestCase
+final class UseExtensionKeyInLocalizationUtilityRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()

--- a/tests/Rector/v10/v0/UseConstantsFromTYPO3DatabaseConnection/UseConstantsFromTYPO3DatabaseConnectionTest.php
+++ b/tests/Rector/v10/v0/UseConstantsFromTYPO3DatabaseConnection/UseConstantsFromTYPO3DatabaseConnectionTest.php
@@ -6,7 +6,7 @@ namespace Ssch\TYPO3Rector\Tests\Rector\v10\v0\UseConstantsFromTYPO3DatabaseConn
 
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-class UseConstantsFromTYPO3DatabaseConnectionTest extends AbstractRectorTestCase
+final class UseConstantsFromTYPO3DatabaseConnectionTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()

--- a/tests/Rector/v14/v0/MigrateObsoleteCharsetInSanitizeFileNameRector/Sources/MyDriver.php
+++ b/tests/Rector/v14/v0/MigrateObsoleteCharsetInSanitizeFileNameRector/Sources/MyDriver.php
@@ -6,7 +6,7 @@ namespace Ssch\TYPO3Rector\Tests\Rector\v14\v0\MigrateObsoleteCharsetInSanitizeF
 
 use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
 
-class MyDriver implements DriverInterface
+final class MyDriver implements DriverInterface
 {
     public function processConfiguration()
     {

--- a/tests/Rector/v14/v0/MigrateObsoleteCharsetInSanitizeFileNameRector/Sources/MyDriver.php
+++ b/tests/Rector/v14/v0/MigrateObsoleteCharsetInSanitizeFileNameRector/Sources/MyDriver.php
@@ -6,7 +6,7 @@ namespace Ssch\TYPO3Rector\Tests\Rector\v14\v0\MigrateObsoleteCharsetInSanitizeF
 
 use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
 
-final class MyDriver implements DriverInterface
+class MyDriver implements DriverInterface
 {
     public function processConfiguration()
     {


### PR DESCRIPTION
StructArmed 0.15.0 introduce `ExtendedClassAwareRuleInterface` that makes `MustBeFinalRule` safely be used to skip if there is class that extend target class.

This PR bump StructArmed to `^0.15` and apply the `MustBeFinalRule` with single command to fix.

```bash
vendor/bin/structarmed analyze --fix
```