### PR TITLE
[BUGFIX] Keep already migrated item keys in the current order

### DIFF
--- a/rules/TYPO312/v3/MigrateItemsIndexedKeysToAssociativeRector.php
+++ b/rules/TYPO312/v3/MigrateItemsIndexedKeysToAssociativeRector.php
@@ -98,6 +98,7 @@ CODE_SAMPLE
 
             if (array_key_exists(0, $exprArrayItem->value->items)
                 && $exprArrayItem->value->items[0] instanceof ArrayItem
+                && ! $exprArrayItem->value->items[0]->key instanceof String_
             ) {
                 $exprArrayItem->value->items[0]->key = new String_('label');
                 $this->hasAstBeenChanged = true;
@@ -106,6 +107,7 @@ CODE_SAMPLE
             if (! $this->isConfigType($configArray, 'check')
                 && array_key_exists(1, $exprArrayItem->value->items)
                 && $exprArrayItem->value->items[1] instanceof ArrayItem
+                && ! $exprArrayItem->value->items[1]->key instanceof String_
             ) {
                 $exprArrayItem->value->items[1]->key = new String_('value');
                 $this->hasAstBeenChanged = true;
@@ -114,6 +116,7 @@ CODE_SAMPLE
             if ($this->isConfigType($configArray, 'select')) {
                 if (array_key_exists(2, $exprArrayItem->value->items)
                     && $exprArrayItem->value->items[2] instanceof ArrayItem
+                    && ! $exprArrayItem->value->items[2]->key instanceof String_
                 ) {
                     $exprArrayItem->value->items[2]->key = new String_('icon');
                     $this->hasAstBeenChanged = true;
@@ -121,6 +124,7 @@ CODE_SAMPLE
 
                 if (array_key_exists(3, $exprArrayItem->value->items)
                     && $exprArrayItem->value->items[3] instanceof ArrayItem
+                    && ! $exprArrayItem->value->items[3]->key instanceof String_
                 ) {
                     $exprArrayItem->value->items[3]->key = new String_('group');
                     $this->hasAstBeenChanged = true;
@@ -128,6 +132,7 @@ CODE_SAMPLE
 
                 if (array_key_exists(4, $exprArrayItem->value->items)
                     && $exprArrayItem->value->items[4] instanceof ArrayItem
+                    && ! $exprArrayItem->value->items[4]->key instanceof String_
                 ) {
                     $exprArrayItem->value->items[4]->key = new String_('description');
                     $this->hasAstBeenChanged = true;

--- a/tests/Rector/v12/v3/tca/MigrateItemsIndexedKeysToAssociativeRector/Fixture/issue-4891.php.inc
+++ b/tests/Rector/v12/v3/tca/MigrateItemsIndexedKeysToAssociativeRector/Fixture/issue-4891.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ssch\TYPO3Rector\Tests\Rector\v12\v3\tca\MigrateItemsIndexedKeysToAssociativeRector\Fixture;
+
+return [
+    'ctrl' => [],
+    'columns' => [
+        'aColumn' => [
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectCheckBox',
+                'items' => [
+                    ['value' => 'top', 'label' => 'top', 'icon' => 'top'],
+                    ['value' => 'left', 'label' => 'left', 'icon' => 'left'],
+                    ['value' => 'right', 'label' => 'right', 'icon' => 'right'],
+                ],
+            ],
+        ],
+        'bColumn' => [
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectCheckBox',
+                'items' => [
+                    ['description' => 'My Description', 'icon' => 'my-icon', 'group' => 'group1', 'label' => 'My label', 'value' => 0],
+                    ['description' => 'My Description', 'icon' => 'my-icon', 'group' => 'group1', 'label' => 'My label 1', 'value' => 1],
+                    ['description' => 'My Description', 'icon' => 'my-icon', 'group' => 'group1', 'label' => 'My label 2', 'value' => 2],
+                    ['description' => 'My Description', 'icon' => 'my-icon', 'group' => 'group1', 'label' => 'My label 3', 'value' => 3],
+                ],
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
Resolves: #4891