### PR TITLE
StructArmed: Enable ExtendedClassMustBeAbstractOrInstantiatedRule

### DIFF
--- a/structarmed.php
+++ b/structarmed.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Rule\Rules\Class_\ExtendedClassMustBeAbstractOrInstantiatedRule;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 return Architecture::define()
     ->rule(
         'source.must_be_final',
         new MustBeFinalRule(layer: 'Source'),
+    )
+    ->rule(
+        'yagni.extended_class.must_be_abstract_or_instantiated',
+        new ExtendedClassMustBeAbstractOrInstantiatedRule(
+            layer: 'Source',
+            classNamePattern: '/^TYPO3\\\\.*\\\\Abstract.*$/',
+        ),
     )
     ->skip([
         '*/MigratePluginContentElementAndPluginSubtypesRector/Assertions/extension*',

--- a/stubs/TYPO3/CMS/Backend/Template/Components/AbstractControl.php
+++ b/stubs/TYPO3/CMS/Backend/Template/Components/AbstractControl.php
@@ -2,7 +2,7 @@
 
 namespace TYPO3\CMS\Backend\Template\Components;
 
-class AbstractControl
+abstract class AbstractControl
 {
     public function setTitle(string $title): self
     {

--- a/stubs/TYPO3/CMS/Backend/Template/Components/Buttons/AbstractButton.php
+++ b/stubs/TYPO3/CMS/Backend/Template/Components/Buttons/AbstractButton.php
@@ -9,7 +9,7 @@ if (class_exists('TYPO3\CMS\Backend\Template\Components\Buttons\AbstractButton')
     return;
 }
 
-class AbstractButton extends AbstractControl implements ButtonInterface
+abstract class AbstractButton extends AbstractControl implements ButtonInterface
 {
     public function setIcon(?Icon $icon): AbstractButton
     {

--- a/stubs/TYPO3/CMS/Extbase/DomainObject/AbstractDomainObject.php
+++ b/stubs/TYPO3/CMS/Extbase/DomainObject/AbstractDomainObject.php
@@ -6,7 +6,7 @@ if (class_exists('TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject')) {
     return;
 }
 
-class AbstractDomainObject implements DomainObjectInterface
+abstract class AbstractDomainObject implements DomainObjectInterface
 {
     public function __wakeup()
     {

--- a/stubs/TYPO3/CMS/Extbase/DomainObject/AbstractEntity.php
+++ b/stubs/TYPO3/CMS/Extbase/DomainObject/AbstractEntity.php
@@ -6,6 +6,6 @@ if (class_exists('TYPO3\CMS\Extbase\DomainObject\AbstractEntity')) {
     return;
 }
 
-class AbstractEntity extends AbstractDomainObject
+abstract class AbstractEntity extends AbstractDomainObject
 {
 }

--- a/stubs/TYPO3/CMS/Fluid/Core/ViewHelper/AbstractViewHelper.php
+++ b/stubs/TYPO3/CMS/Fluid/Core/ViewHelper/AbstractViewHelper.php
@@ -6,6 +6,6 @@ if (class_exists('TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper')) {
     return;
 }
 
-class AbstractViewHelper
+abstract class AbstractViewHelper
 {
 }


### PR DESCRIPTION
StructArmed 0.16 bring YAGNI preset, and one of its rule is: `ExtendedClassMustBeAbstractOrInstantiatedRule`.

The rule is check:

- class is only extended
- class never instantiated

Then class needs to be marked as `abstract`. For safety purpose, this PR register this rule with only apply on `classNamePattern` with `Abstract` prefix in it:

```php
    ->rule(
        'yagni.extended_class.must_be_abstract_or_instantiated',
        new ExtendedClassMustBeAbstractOrInstantiatedRule(
            layer: 'Source',
            classNamePattern: '/^TYPO3\\\\.*\\\\Abstract.*$/',
        ),
    )
```

and applied change is only on `stubs` so should be safer to apply. 

This applied automatically with `--fix` command:

```
➜  typo3-rector git:(main) ✗ vendor/bin/structarmed analyze --fix
Analyzing [============================] 100% 1370/1370

✓  5 violations have been fixed.
```


