### PR TITLE
[BUGFIX] Replace the container APIs rector/rector 2.6.4 removed

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -25,12 +25,12 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->singleton(FilesystemFactory::class, fn () => new FilesystemFactory('/'));
     // This filesystem is used for reading files
-    $rectorConfig->bind(
+    $rectorConfig->singleton(
         LocalFilesystemInterface::class,
         static fn (RectorConfig $app) => $app->make(FilesystemFactory::class)->createLocalFilesystem()
     );
     // This filesystem is used for writing files
-    $rectorConfig->bind(
+    $rectorConfig->singleton(
         FilesystemInterface::class,
         static fn (RectorConfig $app) => $app->make(FilesystemFactory::class)->create()
     );

--- a/config/v12/extbase_annotations_to_attributes.php
+++ b/config/v12/extbase_annotations_to_attributes.php
@@ -7,18 +7,21 @@ use Ssch\TYPO3Rector\TYPO312\AnnotationToAttribute\AttributeDecorator;
 use Ssch\TYPO3Rector\TYPO312\AnnotationToAttribute\CascadeAttributeDecorator;
 use Ssch\TYPO3Rector\TYPO312\AnnotationToAttribute\IgnoreValidationAttributeDecorator;
 use Ssch\TYPO3Rector\TYPO312\AnnotationToAttribute\ValidateAttributeDecorator;
-use Ssch\TYPO3Rector\TYPO312\Contract\AttributeDecoratorInterface;
 use Ssch\TYPO3Rector\TYPO312\v0\ExtbaseAnnotationToAttributeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
 
-    $rectorConfig->autotagInterface(AttributeDecoratorInterface::class);
     $rectorConfig->singleton(CascadeAttributeDecorator::class);
     $rectorConfig->singleton(IgnoreValidationAttributeDecorator::class);
     $rectorConfig->singleton(ValidateAttributeDecorator::class);
-    $rectorConfig->when(AttributeDecorator::class)->needs('$decorators')->giveTagged(
-        AttributeDecoratorInterface::class
+    $rectorConfig->singleton(
+        AttributeDecorator::class,
+        static fn (RectorConfig $app): AttributeDecorator => new AttributeDecorator([
+            $app->make(CascadeAttributeDecorator::class),
+            $app->make(IgnoreValidationAttributeDecorator::class),
+            $app->make(ValidateAttributeDecorator::class),
+        ])
     );
     $rectorConfig->rule(ExtbaseAnnotationToAttributeRector::class);
 };


### PR DESCRIPTION
Fixes #4922.

The analysis in #4922 by @chrissonntag is what made this a short change, and they offered to open a PR themselves — if that is already in progress, close this one, it is meant to save time rather than take the work. The `config/v12` hunk follows the fix proposed there; the `config/config.php` hunk differs, keeping the existing closures and changing only the method name.

## What breaks

rector/rector 2.6.4 swapped `RectorConfig`'s parent container from illuminate/container to entropy/entropy, dropping the inherited container API; rectorphp/rector#9868 says those methods were never public API and are not coming back. Three of them are used here, so every run aborts while the config loads, before any rule executes — and they surface one at a time, so fixing `bind()` reveals `autotagInterface()`.

`config/v12` is not only reached by the TYPO3 12 sets. `config/level/up-to-typo3-14.php` pulls `UP_TO_TYPO3_13`, which chains down to `UP_TO_TYPO3_12` and `Typo3SetList::TYPO3_12`, and `config/typo3-12.php` imports the file. So `UP_TO_TYPO3_12`, `UP_TO_TYPO3_13`, `UP_TO_TYPO3_14` and a direct `Typo3SetList::TYPO3_12` all reach it — v14 projects, which are the most likely to be on a fresh 2.6.4, included.

## What changed

In `config/config.php`, `bind()` becomes `singleton()`. **This is not a lifetime change**, contrary to the trade-off note in #4922. Rector ships a patched illuminate/container whose `resolve()` caches every non-contextual resolution regardless of the shared flag — the `isShared()` test Laravel has is cut out, leaving `if (!$needsContextualBuild) { $this->instances[$abstract] = $object; }` at `Container.php:833` in the 2.6.3 release archive, identical in 2.5.2 and 2.5.9, with illuminate's own `Container::isShared()` left without a caller in that copy. The citation is to the archive rather than to an installed tree because 2.6.4 no longer vendors illuminate at all. So `bind()` already returned one instance per container, and entropy does the same inside `make()` on 2.6.4.

This repository depends on that sharing: 15 test classes resolve `FilesystemInterface` from the container in `setUp()` and then read back what a rule wrote through its own injected instance. Under PHPUnit the factory builds an `InMemoryFilesystemAdapter`, so two separate instances would not see each other's writes at all. Both methods take the same `(string $abstract, callable $concrete)` shape and both call the factory with the container, so the closures are untouched.

In `config/v12/extbase_annotations_to_attributes.php`, `autotagInterface()` and `when()->needs()->giveTagged()` are replaced by an explicit singleton that builds `AttributeDecorator` from the three decorators, using `make()` rather than `new` because `ValidateAttributeDecorator` has constructor dependencies. All three implementations of `AttributeDecoratorInterface` in this repository are in that list, and their `supports()` checks cover disjoint attribute names, so order does not matter.

The fixed list does cost something: a third-party decorator can no longer register itself by implementing the interface, and it fails silently — the decoration is simply not applied, with no error. There is no portable replacement while `rector/rector: ^2.5.2` is declared, so an explicit list looks like the only option that spans the range, but it is worth a release note.

## Verification

The existing suite is the regression guard, and it was seen to fail before it was seen to pass: on unmodified `main` with rector 2.6.4, `vendor/bin/phpunit --filter ExtbaseAnnotationToAttributeRector` errors twice on `Call to undefined method Rector\Config\RectorConfig::bind()` and `composer ci:check-typo3-rector` exits 1 on the same message. With the patch, both are green.

`phpunit` and `ci:check-typo3-rector` were run at four Rector versions inside the declared `^2.5.2` range:

| rector/rector | `vendor/bin/phpunit` | `ci:check-typo3-rector` |
|---|---|---|
| 2.5.9 | 556 tests, 0 failures | OK |
| 2.6.0 | 556 tests, 0 failures | OK |
| 2.6.3 | 556 tests, 0 failures | OK |
| 2.6.4 | 556 tests, 0 failures | OK |

2.6.3 is the newest version where both the patched and the unpatched config load, so it also allows a direct before/after on behaviour rather than just on exit codes. Running the suite there against this branch and against the two files restored from `2f9379ec` gives the same numbers down to the assertion: 556 tests, 902 assertions, 41 skipped, 1 deprecation in both. The patch changes what the container is asked for, not what comes out of it.

At 2.6.4 additionally, and only there: `ci:php:lint`, `ci:check-style`, `composer validate --strict`, `ci:composer:normalize`, `sameBeforeAfterFixtureDetector.php`, `noPhpFileInFixturesDetector.php`, and `structarmed analyze` (0 violations, installed the way the workflow installs it, then reverted `composer.json`). Both changed files also lint clean under `php:7.4-cli`, the floor of the CI matrix.

No second wave is waiting: every `RectorConfig` method called anywhere in `config/` and `templates/` — `import`, `importNames`, `importShortClasses`, `make`, `phpVersion`, `phpstanConfig`, `rule`, `ruleWithConfiguration`, `sets`, `singleton` — still exists on 2.6.4, as do the eight `RectorConfigBuilder` methods actually called by `rector.php` and `templates/rector.php.dist` (a ninth, `withPhpSets()`, appears only commented out). A grep for `->bind(`, `->autotagInterface(`, `->when(`, `->tagged(`, `->bindMethod(`, `->singletonIf(` and `->scoped(` across `config/ src/ rules/ tests/ utils/ templates/` returns nothing. (The same alternation unanchored returns nine hits, all string literals and comments such as `'tabindex'`.)

## Three things I could not make green, none of them from this change

At the `2.5.2` floor the suite dies in `PHPStanContainerMemento::removeRichVisitors()`. I ran it with and without this patch and got an identical stack and exit status both times, so that floor is already broken in a fresh install today and this change neither causes nor fixes it. It is why the table starts at 2.5.9.

`ci:php:stan` reports four `offsetAccess.invalidOffset` errors in `rules/TYPO313` and `rules/TYPO314`, and `ci:rector` reports three files it would rewrite in `rules/` and `src/`. All are present on unmodified `main` in a fresh install today, and none is in a file this PR touches. CI last ran on `main` on 2026-08-21, before rector 2.6.4 and the current phpstan resolved, so these look like dependency drift rather than a regression in the repository; with no `composer.lock`, every run re-resolves. Comparing raw phpstan error sets before and after: this patch removes exactly the four `method.notFound` errors for `bind()`, `autotagInterface()` and `when()`, and introduces none — 8 on `main`, 4 with the patch, no new entries. `config/` is inside `phpstan.neon`'s `paths`, so the changed files are analysed and are clean.

I deliberately did not run `composer local:contribute` into this branch. It chains `fix:rector`, `fix:style`, `ci:php:stan` and `phpstan:baseline`, and the first and last of those would have swept the three unrelated rewrites and a regenerated baseline into a two-file config fix. I ran each of its steps separately instead and confirmed none of them wants to touch the files changed here.

## One thing that lands with 2.6.4 regardless of this PR

Overriding one of these bindings from a user's own `rector.php` flips from last-wins to first-wins. On 2.5.x, `bind()` dropped a stale instance and replaced the registration; on 2.6.4, `singleton()` guards with `if (!isset($this->factoryBound[$abstract]))`, so the first registration wins and a later one is silently ignored. Anyone registering their own `FilesystemInterface` after `sets([...])` will need to move it before. That is rector 2.6.4 behaviour, not something this patch introduces, but it reaches users in the same release.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
