### PR TITLE
[BUGFIX] Fix MigrateLabelReferenceToDomainSyntaxRector

### DIFF
--- a/rules/TYPO314/v0/MigrateLabelReferenceToDomainSyntaxRector.php
+++ b/rules/TYPO314/v0/MigrateLabelReferenceToDomainSyntaxRector.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Ssch\TYPO3Rector\TYPO314\v0;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\VariadicPlaceholder;
 use PHPStan\Type\ObjectType;
-use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -21,16 +21,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MigrateLabelReferenceToDomainSyntaxRector extends AbstractRector implements DocumentedRuleInterface
 {
-    /**
-     * @readonly
-     */
-    private ValueResolver $valueResolver;
-
-    public function __construct(ValueResolver $valueResolver)
-    {
-        $this->valueResolver = $valueResolver;
-    }
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Migrate LLL references to the new domain-based notation', [new CodeSample(
@@ -70,8 +60,15 @@ CODE_SAMPLE
             return null;
         }
 
-        $value = $this->valueResolver->getValue($firstArg->value);
-        if (! is_string($value) || strpos($value, 'LLL:EXT:') !== 0) {
+        // Keep any concatenated variables/expressions untouched and only migrate
+        // the leading string literal, e.g. 'LLL:EXT:...:key.' . $variable
+        $leadingString = $this->resolveLeadingString($firstArg->value);
+        if (! $leadingString instanceof String_) {
+            return null;
+        }
+
+        $value = $leadingString->value;
+        if (strpos($value, 'LLL:EXT:') !== 0) {
             return null;
         }
 
@@ -80,9 +77,26 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->args[0]->value = new String_($transformed);
+        $leadingString->value = $transformed;
 
         return $node;
+    }
+
+    /**
+     * Resolves the left-most string literal of a (possibly nested) concatenation,
+     * so it can be rewritten in place while keeping the remaining expression parts intact.
+     */
+    private function resolveLeadingString(Node $expr): ?String_
+    {
+        if ($expr instanceof String_) {
+            return $expr;
+        }
+
+        if ($expr instanceof Concat) {
+            return $this->resolveLeadingString($expr->left);
+        }
+
+        return null;
     }
 
     private function transformLllString(string $lll): string

--- a/tests/Rector/v14/v0/MigrateLabelReferenceToDomainSyntaxRector/Fixture/fixture.php.inc
+++ b/tests/Rector/v14/v0/MigrateLabelReferenceToDomainSyntaxRector/Fixture/fixture.php.inc
@@ -26,6 +26,12 @@ $label = $lang->sL('LLL:EXT:core/Resources/Private/Language/de.locallang.xlf:lab
 
 $label = $lang->sL('LLL:EXT:core/Resources/Private/Language/locallang_command.xlf:permissionset.check.preset_not_applied');
 
+$success = true;
+$label = $lang->sL('LLL:EXT:core/Resources/Private/Language/locallang_command.xlf:permissionset.check.preset_not_applied' . ($success ? 'success' : 'error'));
+
+$deficit = 'asdf';
+$label = $lang->sL('LLL:EXT:core/Resources/Private/Language/locallang_command.xlf:permissionset.check.preset_not_applied.' . $deficit . '.message');
+
 ?>
 -----
 <?php
@@ -55,5 +61,11 @@ $label = $lang->sL('site_ext.user_profile.messages:name');
 $label = $lang->sL('core.messages:labels.open');
 
 $label = $lang->sL('core.command:permissionset.check.preset_not_applied');
+
+$success = true;
+$label = $lang->sL('core.command:permissionset.check.preset_not_applied' . ($success ? 'success' : 'error'));
+
+$deficit = 'asdf';
+$label = $lang->sL('core.command:permissionset.check.preset_not_applied.' . $deficit . '.message');
 
 ?>


### PR DESCRIPTION
Handle variables in sL() as well and keep them